### PR TITLE
ci: build and publish chart/image upon merging to main

### DIFF
--- a/.github/workflows/publish-dev-charts.yml
+++ b/.github/workflows/publish-dev-charts.yml
@@ -1,0 +1,26 @@
+name: publish-dev-chart
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: deployments

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -1,0 +1,84 @@
+name: publish-dev-ghcr
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write
+    environment: azure-publish
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install Notation
+        uses: notaryproject/notation-action/setup@b6fee73110795d6793253c673bd723f12bcf9bbb # v1.2.2
+      - name: Az CLI login
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Cache AAD tokens
+        run: |
+          az version
+          # Key Vault: 
+          az account get-access-token --scope https://vault.azure.net/.default --output none
+      - name: Prepare notation certificate
+        run: |
+          mkdir -p truststore/x509/ca/ratify-verify
+          cp ./.well-known/pki-validation/ratify-verification.crt truststore/x509/ca/ratify-verify
+      - name: prepare
+        id: prepare
+        run: |
+          ORG_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f1)
+          REPOSITORY=ghcr.io/${ORG_NAME}/ratify-gatekeeper-provider
+          echo "ref=${REPOSITORY}:dev" >> $GITHUB_OUTPUT
+      - name: docker login
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: docker build ratify
+        run: |
+          docker buildx create --use         
+          docker buildx build -f ./Dockerfile \
+            --attest type=provenance,mode=max \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --label org.opencontainers.image.revision=${{ github.sha }} \
+            -t ${{ steps.prepare.outputs.ref }} \
+            --push .
+      - name: Sign with Notation
+        uses: notaryproject/notation-action/sign@b6fee73110795d6793253c673bd723f12bcf9bbb # v1.2.2
+        with:
+          plugin_name: azure-kv
+          plugin_url: ${{ vars.AZURE_KV_PLUGIN_URL }}
+          plugin_checksum: ${{ vars.AZURE_KV_CHECKSUM }}
+          key_id: ${{ secrets.AZURE_KV_KEY_ID }}
+          target_artifact_reference: |-
+            ${{ steps.prepare.outputs.ref }}
+          signature_format: cose
+      - name: Verify with Notation
+        uses: notaryproject/notation-action/verify@b6fee73110795d6793253c673bd723f12bcf9bbb # v1.2.2
+        with:
+          target_artifact_reference: |-
+            ${{ steps.prepare.outputs.ref }}
+          trust_policy: ./.well-known/pki-validation/trustpolicy.json
+          trust_store: truststore
+      - name: clear
+        if: always()
+        run: |
+          rm -f ${HOME}/.docker/config.json

--- a/deployments/ratify-gatekeeper-provider/Chart.yaml
+++ b/deployments/ratify-gatekeeper-provider/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ratify-gatekeeper-provider
 description: A Helm chart for Ratify
 type: application
-version: 2.0.0-alpha.1
-appVersion: "2.0.0-alpha.1"
+version: 2.0.0-dev
+appVersion: "2.0.0-dev"
 home: https://github.com/notaryproject/ratify
 icon: https://raw.githubusercontent.com/notaryproject/ratify/main/assets/logo.svg

--- a/deployments/ratify-gatekeeper-provider/values.yaml
+++ b/deployments/ratify-gatekeeper-provider/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: "ghcr.io/notaryproject/ratify-gatekeeper-provider"
   pullPolicy: IfNotPresent
-  tag: ""
+  tag: "dev"
 
 replicaCount: 1
 


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
Add pipeline to build and publish chart/image upon merging to main. Each merge will result to an updated ghcr.io/ratify-gatekeeper-provider:dev image and a new chart with version 2.0.0-dev

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
