### PR TITLE
refactor: apply go convention to the package `internal/pod`

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -90,8 +90,8 @@ func setupCertRotator(certRotatorReady chan struct{}, mgr ctrl.Manager, disableM
 		})
 	}
 
-	namespace := pod.GetNamespace()
-	serviceName := pod.GetServiceName()
+	namespace := pod.Namespace()
+	serviceName := pod.ServiceName()
 
 	if err := rotator.AddRotator(mgr, &rotator.CertRotator{
 		SecretKey: types.NamespacedName{

--- a/internal/pod/info.go
+++ b/internal/pod/info.go
@@ -17,8 +17,8 @@ package pod
 
 import "os"
 
-// GetNamespace returns the namespace.
-func GetNamespace() string {
+// Namespace returns the namespace.
+func Namespace() string {
 	ns, found := os.LookupEnv("RATIFY_NAMESPACE")
 	if !found {
 		return "gatekeeper-system"
@@ -26,8 +26,8 @@ func GetNamespace() string {
 	return ns
 }
 
-// GetServiceName returns the service name.
-func GetServiceName() string {
+// ServiceName returns the service name.
+func ServiceName() string {
 	name, found := os.LookupEnv("RATIFY_NAME")
 	if !found {
 		return "ratify-gatekeeper-provider"

--- a/internal/pod/info_test.go
+++ b/internal/pod/info_test.go
@@ -24,7 +24,7 @@ func TestGetNamespace(t *testing.T) {
 	// Test case 1: Environment variable "RATIFY_NAMESPACE" is not set
 	t.Run("Environment variable not set", func(t *testing.T) {
 		expected := "gatekeeper-system"
-		actual := GetNamespace()
+		actual := Namespace()
 		if actual != expected {
 			t.Errorf("Expected namespace to be %q, but got %q", expected, actual)
 		}
@@ -39,7 +39,7 @@ func TestGetNamespace(t *testing.T) {
 		}
 
 		expected := "custom-namespace"
-		actual := GetNamespace()
+		actual := Namespace()
 		if actual != expected {
 			t.Errorf("Expected namespace to be %q, but got %q", expected, actual)
 		}
@@ -62,7 +62,7 @@ func TestGetServiceName(t *testing.T) {
 		}
 
 		expected := "ratify-gatekeeper-provider"
-		actual := GetServiceName()
+		actual := ServiceName()
 		if actual != expected {
 			t.Errorf("Expected service name to be %q, but got %q", expected, actual)
 		}
@@ -77,7 +77,7 @@ func TestGetServiceName(t *testing.T) {
 		}
 
 		expected := "custom-service-name"
-		actual := GetServiceName()
+		actual := ServiceName()
 		if actual != expected {
 			t.Errorf("Expected service name to be %q, but got %q", expected, actual)
 		}


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
This PR refactors the `internal/pod` package to follow Go naming conventions. It renames `podinfo.go` to `info.go` and updates the exported functions `GetNamespace` and `GetServiceName` to `Namespace` and `ServiceName`. All usages and tests are updated accordingly. This improves code clarity and consistency with Go best practices.

## Type of change

Please delete options that are not relevant.

- [x] Refactor (code style, no functional changes, no API changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests for `internal/pod` updated and passing
- [x] Verified all references to the renamed functions and files are updated

# Checklist:

- [x] Does the affected code have corresponding tests?
- [x] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`