### PR TITLE
feat(store): add StoreMux wildcard scope fallback

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -72,17 +72,19 @@ type Options struct {
 //   - Repository paths: "registry.example.com/namespace/repo" matches a
 //     specific repository
 //
-// Note: Top level domain wildcard is also not supported. That is, "*" is not a
-// valid pattern.
+// Note: Top level domain wildcard patterns like "*.com" are not supported.
+// The special scope value "*" is reserved for the global fallback executor.
 // Scope matching follows a precedence order from most specific to least
 // specific:
 //  1. Exact repository match
 //  2. Exact registry match
 //  3. Wildcard registry match
+//  4. Fallback executor
 type ScopedExecutor struct {
 	wildcard   map[string]*ratify.Executor
 	registry   map[string]*ratify.Executor
 	repository map[string]*ratify.Executor
+	fallback   *ratify.Executor
 }
 
 // NewScopedExecutor creates a new ScopedExecutor instance based on the provided
@@ -191,6 +193,9 @@ func (s *ScopedExecutor) matchExecutor(artifact string) (*ratify.Executor, error
 			return executor, nil
 		}
 	}
+	if s.fallback != nil {
+		return s.fallback, nil
+	}
 	return nil, fmt.Errorf("no executor configured for the artifact %q", artifact)
 }
 
@@ -201,6 +206,13 @@ func (s *ScopedExecutor) registerExecutor(scope string, executor *ratify.Executo
 	}
 	if executor == nil {
 		return fmt.Errorf("executor cannot be nil")
+	}
+	if scope == "*" {
+		if s.fallback != nil {
+			return fmt.Errorf("fallback executor already registered")
+		}
+		s.fallback = executor
+		return nil
 	}
 
 	if strings.Contains(scope, "/") {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -112,7 +112,7 @@ func TestNewExecutor(t *testing.T) {
 			expectExecutor: false,
 		},
 		{
-			name: "invalid executor scopes",
+			name: "valid fallback scope",
 			opts: Options{
 				Executors: []ScopedOptions{
 					{
@@ -125,8 +125,7 @@ func TestNewExecutor(t *testing.T) {
 						},
 						Stores: []store.NewOptions{
 							{
-								Type:   mockStoreType,
-								Scopes: []string{"testrepo"},
+								Type: mockStoreType,
 							},
 						},
 						Policy: &policyenforcer.NewOptions{
@@ -135,8 +134,8 @@ func TestNewExecutor(t *testing.T) {
 					},
 				},
 			},
-			expectErr:      true,
-			expectExecutor: false,
+			expectErr:      false,
+			expectExecutor: true,
 		},
 		{
 			name: "failed to create store",
@@ -234,12 +233,14 @@ func TestRegisterExecutor(t *testing.T) {
 		wildcardScoped   bool
 		registryScoped   bool
 		repositoryScoped bool
+		fallbackScoped   bool
 	}{
 		{
-			name:          "Register executor with global wildcard scope",
-			scope:         "*",
-			executor:      &ratify.Executor{},
-			registerError: true,
+			name:           "Register executor with fallback scope",
+			scope:          "*",
+			executor:       &ratify.Executor{},
+			registerError:  false,
+			fallbackScoped: true,
 		},
 		{
 			name:          "Register executor with empty scope",
@@ -323,6 +324,9 @@ func TestRegisterExecutor(t *testing.T) {
 				if test.repositoryScoped && len(scopedExecutor.repository) == 0 {
 					t.Errorf("expected repository scoped executors to be registered, but got none")
 				}
+				if test.fallbackScoped && scopedExecutor.fallback == nil {
+					t.Errorf("expected fallback executor to be registered, but got none")
+				}
 			}
 		})
 	}
@@ -332,6 +336,7 @@ func TestMatchExecutor(t *testing.T) {
 	e1 := &ratify.Executor{}
 	e2 := &ratify.Executor{}
 	e3 := &ratify.Executor{}
+	e4 := &ratify.Executor{}
 	scopedExecutor := &ScopedExecutor{
 		wildcard: map[string]*ratify.Executor{
 			"example.com": e1,
@@ -342,6 +347,7 @@ func TestMatchExecutor(t *testing.T) {
 		repository: map[string]*ratify.Executor{
 			"registry.example.com/repository/foo": e3,
 		},
+		fallback: e4,
 	}
 	tests := []struct {
 		name             string
@@ -374,10 +380,10 @@ func TestMatchExecutor(t *testing.T) {
 			expectedError:    false,
 		},
 		{
-			name:             "No match",
+			name:             "Match fallback executor",
 			artifact:         "unknown.com/foo:v1",
-			expectedExecutor: nil,
-			expectedError:    true,
+			expectedExecutor: e4,
+			expectedError:    false,
 		},
 	}
 
@@ -399,10 +405,11 @@ func TestValidateArtifact(t *testing.T) {
 		wildcard: map[string]*ratify.Executor{
 			"example.com": {},
 		},
+		fallback: &ratify.Executor{},
 	}
 
 	if _, err := scopedExecutor.ValidateArtifact(context.Background(), "unknown.com/foo:v1"); err == nil {
-		t.Error("expected error for unknown artifact, got nil")
+		t.Error("expected error for fallback executor without store/verifiers, got nil")
 	}
 
 	if _, err := scopedExecutor.ValidateArtifact(context.Background(), "test.example.com/foo:v1"); err == nil {

--- a/internal/store/factory.go
+++ b/internal/store/factory.go
@@ -59,25 +59,49 @@ func New(opts []NewOptions, globalScopes []string) (ratify.Store, error) {
 	if len(opts) == 0 {
 		return nil, fmt.Errorf("no store options provided")
 	}
+
+	if len(opts) == 1 && len(opts[0].Scopes) == 0 && len(globalScopes) == 0 {
+		store, err := newStore(opts[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to create store for type %q: %w", opts[0].Type, err)
+		}
+		storeMux := ratify.NewStoreMux()
+		if err = storeMux.RegisterFallback(store); err != nil {
+			return nil, fmt.Errorf("failed to register fallback store: %w", err)
+		}
+		return storeMux, nil
+	}
+
 	// If there is more than one store option, clear the global scopes as
 	// multiple stores should not share the same global scopes.
 	if len(opts) > 1 {
 		globalScopes = []string{}
 	}
+
 	storeMux := ratify.NewStoreMux()
 	for _, storeOptions := range opts {
-		if len(storeOptions.Scopes) == 0 {
+		scopes := storeOptions.Scopes
+		if len(scopes) == 0 {
 			// if no scopes are provided, use the global scopes of the executor.
-			storeOptions.Scopes = globalScopes
+			scopes = globalScopes
 		}
-		if len(storeOptions.Scopes) == 0 {
-			return nil, fmt.Errorf("store options must contain at least one scope")
-		}
+
 		store, err := newStore(storeOptions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create store for type %q: %w", storeOptions.Type, err)
 		}
-		for _, scope := range storeOptions.Scopes {
+
+		if len(scopes) == 1 && scopes[0] == "*" {
+			if err = storeMux.RegisterFallback(store); err != nil {
+				return nil, fmt.Errorf("failed to register fallback store: %w", err)
+			}
+			continue
+		}
+
+		if len(scopes) == 0 {
+			return nil, fmt.Errorf("store options must contain at least one scope")
+		}
+		for _, scope := range scopes {
 			if err = storeMux.Register(scope, store); err != nil {
 				return nil, fmt.Errorf("failed to register store for scope %q: %w", scope, err)
 			}

--- a/internal/store/factory_test.go
+++ b/internal/store/factory_test.go
@@ -162,15 +162,15 @@ func TestNew(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "invalid store scope",
+			name: "fallback store with star scope",
 			opts: []NewOptions{
 				{
 					Type:       "mock-store",
 					Parameters: map[string]any{},
+					Scopes:     []string{"*"},
 				},
 			},
-			globalScopes:  []string{"*"},
-			expectedError: true,
+			expectedError: false,
 		},
 		{
 			name: "multiple stores clear global scopes",
@@ -188,15 +188,24 @@ func TestNew(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "store registration failure with bad store type",
+			name: "store creation failure with fallback scope",
 			opts: []NewOptions{
 				{
 					Type:   "mock-store-with-error",
-					Scopes: []string{"*"}, // Invalid scope that causes Register to fail
+					Scopes: []string{"*"},
 				},
 			},
 			globalScopes:  []string{},
 			expectedError: true,
+		},
+		{
+			name: "single store without scopes registers fallback",
+			opts: []NewOptions{
+				{
+					Type: "mock-store",
+				},
+			},
+			expectedError: false,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- treat `*` as the fallback scope when wiring StoreMux stores
- support fallback scoped executors alongside exact and wildcard scope matches
- extend unit coverage for fallback registration and resolution paths

## Testing
- go test ./internal/store ./internal/executor