### PR TITLE
feat: add per-request trace IDs and system-error metrics

### DIFF
--- a/internal/httpserver/handlers.go
+++ b/internal/httpserver/handlers.go
@@ -25,11 +25,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/notaryproject/ratify/v2/internal/logger"
 	"github.com/notaryproject/ratify/v2/pkg/metrics"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
-	"github.com/sirupsen/logrus"
 	"oras.land/oras-go/v2/registry"
 )
+
+var logOpt = logger.Option{ComponentType: logger.Server}
 
 // verify handles the verification request from Gatekeeper.
 func (s *server) verify(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
@@ -73,12 +75,13 @@ func (s *server) verify(ctx context.Context, w http.ResponseWriter, r *http.Requ
 			}
 			renderedResult := convertResult(result)
 			if err = s.verifyCache.Set(ctx, key, renderedResult, 0); err != nil {
-				logrus.Warnf("failed to set verify cache for image %s: %v", artifact, err)
+				logger.GetLogger(ctx, logOpt).Warnf("failed to set verify cache for image %s: %v", artifact, err)
 			}
 			return renderedResult, nil
 		})
 		if err != nil {
 			results[idx].Error = err.Error()
+			metrics.ReportSystemError(ctx, "verify_artifact")
 		}
 		results[idx].Value = val
 	}
@@ -119,6 +122,7 @@ func (s *server) resolveReference(ctx context.Context, key string) externaldata.
 	ref, err := registry.ParseReference(reference)
 	if err != nil {
 		item.Error = fmt.Sprintf("failed to parse reference: %v", err)
+		metrics.ReportSystemError(ctx, "mutate_parse_reference")
 		return item
 	}
 	if _, err = ref.Digest(); err == nil {
@@ -150,12 +154,13 @@ func (s *server) resolveReference(ctx context.Context, key string) externaldata.
 		resolvedRef := ref.String()
 
 		if err = s.mutateCache.Set(ctx, cacheKey, resolvedRef, 0); err != nil {
-			logrus.Warnf("failed to set mutate cache for image %s: %v", reference, err)
+			logger.GetLogger(ctx, logOpt).Warnf("failed to set mutate cache for image %s: %v", reference, err)
 		}
 		return resolvedRef, nil
 	})
 	if err != nil {
 		item.Error = err.Error()
+		metrics.ReportSystemError(ctx, "mutate_resolve_reference")
 	} else {
 		item.Value = val
 	}

--- a/internal/httpserver/handlers_test.go
+++ b/internal/httpserver/handlers_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/notaryproject/ratify/v2/internal/executor"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -398,5 +400,86 @@ func TestVerifyStripsNamespacePrefix(t *testing.T) {
 	}
 	if strings.Contains(itemErr, "parse") {
 		t.Errorf("prefixed key should be stripped before parsing; got parse error: %q", itemErr)
+	}
+}
+
+func newHandlerTestServer() *server {
+	return &server{
+		getExecutor: func(_ string) *executor.ScopedExecutor { return nil },
+		sfGroup:     &singleflight.Group{},
+		verifyCache: &mockResultCache{entries: make(map[string]*result)},
+		mutateCache: &mockCache{entries: make(map[string]string)},
+	}
+}
+
+// findEntry returns the first log entry at the given level whose message
+// contains want. The logrus hook is global, so tests must match on their own
+// message rather than assuming they are the only writer.
+func findEntry(hook *test.Hook, level logrus.Level, want string) *logrus.Entry {
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == level && strings.Contains(entry.Message, want) {
+			return entry
+		}
+	}
+	return nil
+}
+
+func TestVerifyHandler(t *testing.T) {
+	srv := newHandlerTestServer()
+	body := `{"apiVersion":"externaldata.gatekeeper.sh/v1beta1","kind":"ProviderRequest","request":{"keys":["ghcr.io/org/image:v1"]}}`
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	srv.verifyHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("verifyHandler() status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestVerifyHandler_LogsFailure(t *testing.T) {
+	hook := test.NewLocal(logrus.StandardLogger())
+	defer hook.Reset()
+
+	srv := newHandlerTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader("not json"))
+	srv.verifyHandler().ServeHTTP(httptest.NewRecorder(), req)
+
+	entry := findEntry(hook, logrus.ErrorLevel, "failed to handle the verification request")
+	if entry == nil {
+		t.Fatal("expected the verify handler to log the error it previously discarded")
+	}
+	if entry.Data["trace-id"] == nil {
+		t.Error("expected the logged entry to carry a trace ID")
+	}
+}
+
+func TestMutateHandler(t *testing.T) {
+	srv := newHandlerTestServer()
+	body := `{"apiVersion":"externaldata.gatekeeper.sh/v1beta1","kind":"ProviderRequest","request":{"keys":["ghcr.io/org/image:v1"]}}`
+	req := httptest.NewRequest(http.MethodPost, "/mutate", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	srv.mutateHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("mutateHandler() status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestMutateHandler_LogsFailure(t *testing.T) {
+	hook := test.NewLocal(logrus.StandardLogger())
+	defer hook.Reset()
+
+	srv := newHandlerTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/mutate", strings.NewReader("not json"))
+	srv.mutateHandler().ServeHTTP(httptest.NewRecorder(), req)
+
+	entry := findEntry(hook, logrus.ErrorLevel, "failed to handle the mutation request")
+	if entry == nil {
+		t.Fatal("expected the mutate handler to log the error it previously discarded")
+	}
+	if entry.Data["trace-id"] == nil {
+		t.Error("expected the logged entry to carry a trace ID")
 	}
 }

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/notaryproject/ratify/v2/internal/executor"
 	"github.com/notaryproject/ratify/v2/internal/httpserver/config"
 	"github.com/notaryproject/ratify/v2/internal/httpserver/tlssecret"
+	"github.com/notaryproject/ratify/v2/internal/logger"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 )
@@ -200,13 +201,13 @@ func (s *server) registerVerifyHandler() error {
 
 func (s *server) verifyHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_ = s.verify(r.Context(), w, r)
+		_ = s.verify(logger.InitContext(r.Context(), r), w, r)
 	}
 }
 
 func (s *server) mutateHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_ = s.mutate(r.Context(), w, r)
+		_ = s.mutate(logger.InitContext(r.Context(), r), w, r)
 	}
 }
 

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -201,13 +201,19 @@ func (s *server) registerVerifyHandler() error {
 
 func (s *server) verifyHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_ = s.verify(logger.InitContext(r.Context(), r), w, r)
+		ctx := logger.InitContext(r.Context(), r)
+		if err := s.verify(ctx, w, r); err != nil {
+			logger.GetLogger(ctx, logOpt).Errorf("failed to handle the verification request: %v", err)
+		}
 	}
 }
 
 func (s *server) mutateHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_ = s.mutate(logger.InitContext(r.Context(), r), w, r)
+		ctx := logger.InitContext(r.Context(), r)
+		if err := s.mutate(ctx, w, r); err != nil {
+			logger.GetLogger(ctx, logOpt).Errorf("failed to handle the mutation request: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Improves log correlation and error observability for the provider's request path.

Now rebased directly onto `main` — the metrics wiring it depended on landed with #2848, and the now-empty #2847 was closed. This PR is a single commit against `main`.

### Change

- **Per-request trace IDs**: attach a **generated** trace ID to each `verify`/`mutate` request context via `logger.InitContext`. It propagates to all context-aware downstream logging — executor, verifiers, auth providers, policy providers — so a single request's logs correlate. (Reading the trace ID from an incoming request header is supported by `internal/logger` but requires `InitLogConfig` to register the header names, which this binary does not call today; that can be wired up in a follow-up.)
- **Context-aware handler logging**: the handler cache-warning logs now use the context logger, so they carry the trace ID too.
- **System-error metric**: count handler/processing failures (executor validate/resolve errors, reference parse errors) with `metrics.ReportSystemError`, using **stable, low-cardinality category labels** (`verify_artifact`, `mutate_parse_reference`, `mutate_resolve_reference`) so Prometheus label cardinality stays bounded. The full error text is still returned to the caller in the response item.

Further metric-coverage expansion (outcome labels on request histograms, cache hit/miss and registry/downstream counters) is left as a follow-up.

#2873 builds on this branch and adds request-outcome logging.

### Testing

- `go build ./...`, `go vet`, package tests, and `golangci-lint` pass. `ReportSystemError` is nil-guarded so it is a no-op when metrics are disabled.
