### PR TITLE
feat: add Dapr distributed cache provider

### DIFF
--- a/cmd/ratify-gatekeeper-provider/main.go
+++ b/cmd/ratify-gatekeeper-provider/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/notaryproject/ratify/v2/internal/httpserver"
 	"github.com/notaryproject/ratify/v2/internal/manager"
 	"github.com/notaryproject/ratify/v2/pkg/common"
+	"github.com/notaryproject/ratify/v2/pkg/featureflag"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,6 +37,7 @@ var startManagerFunc = manager.StartManager
 // main is the entry point for the Ratify server.
 func main() {
 	common.SetLoggingLevelFromEnv(logrus.StandardLogger())
+	featureflag.InitFeatureFlagsFromEnv()
 	if err := startRatify(parse()); err != nil {
 		logrus.Errorf("Failed to start Ratify: %v", err)
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.32
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.28.6
 	github.com/bombsimon/logrusr/v4 v4.1.0
+	github.com/dapr/go-sdk v1.8.0
 	github.com/dgraph-io/ristretto/v2 v2.2.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.5.3+incompatible
@@ -99,6 +100,7 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-containerregistry v0.21.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
 github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
+github.com/dapr/go-sdk v1.8.0 h1:OEleeL3zUTqXxIZ7Vkk3PClAeCh1g8sZ1yR2JFZKfXM=
+github.com/dapr/go-sdk v1.8.0/go.mod h1:MBcTKXg8PmBc8A968tVWQg1Xt+DZtmeVR6zVVVGcmeA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/internal/cache/dapr/dapr.go
+++ b/internal/cache/dapr/dapr.go
@@ -107,7 +107,11 @@ func (d *Cache[T]) Set(ctx context.Context, key string, value T, ttl time.Durati
 
 	var md map[string]string
 	if ttl > 0 {
-		md = map[string]string{"ttlInSeconds": strconv.Itoa(int(ttl.Seconds()))}
+		// Round up to the nearest second using integer duration math so that
+		// any positive TTL maps to at least 1 second (avoids sending
+		// ttlInSeconds=0, which would disable expiry, for sub-second TTLs).
+		seconds := int64((ttl + time.Second - 1) / time.Second)
+		md = map[string]string{"ttlInSeconds": strconv.FormatInt(seconds, 10)}
 	}
 
 	if err := d.daprClient.SaveState(ctx, d.cacheName, ctxUtils.CreateCacheKey(ctx, key), bytes, md); err != nil {

--- a/internal/cache/dapr/dapr.go
+++ b/internal/cache/dapr/dapr.go
@@ -1,0 +1,125 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dapr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/dapr/go-sdk/client"
+	"github.com/notaryproject/ratify/v2/internal/cache"
+	ctxUtils "github.com/notaryproject/ratify/v2/internal/context"
+	"github.com/notaryproject/ratify/v2/pkg/featureflag"
+)
+
+// DefaultCacheName is the default Dapr state store component name.
+const DefaultCacheName = "dapr-redis"
+
+// stateClient captures the subset of the Dapr client used by the cache. It
+// keeps the implementation testable without a running Dapr sidecar and is
+// satisfied by client.Client.
+type stateClient interface {
+	GetState(ctx context.Context, storeName, key string, meta map[string]string) (*client.StateItem, error)
+	SaveState(ctx context.Context, storeName, key string, data []byte, meta map[string]string, so ...client.StateOption) error
+	DeleteState(ctx context.Context, storeName, key string, meta map[string]string) error
+}
+
+// Cache is a distributed cache backed by a Dapr state store. Values are
+// JSON-encoded so that any type T can be shared across replicas, enabling the
+// high-availability deployment mode.
+type Cache[T any] struct {
+	daprClient stateClient
+	cacheName  string
+	ttl        time.Duration
+}
+
+// NewCache creates a new Dapr-backed cache with the specified state store name
+// and default TTL. It requires the high-availability feature flag to be
+// enabled and a reachable Dapr sidecar.
+func NewCache[T any](cacheName string, ttl time.Duration) (cache.Cache[T], error) {
+	if !featureflag.HighAvailability.Enabled {
+		return nil, fmt.Errorf("dapr cache provider is not enabled: set the environment variable RATIFY_EXPERIMENTAL_HIGH_AVAILABILITY=1 to enable it")
+	}
+	if ttl < 0 {
+		return nil, cache.ErrInvalidTTL
+	}
+	if cacheName == "" {
+		cacheName = DefaultCacheName
+	}
+
+	daprClient, err := client.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dapr client: %w", err)
+	}
+
+	return &Cache[T]{
+		daprClient: daprClient,
+		cacheName:  cacheName,
+		ttl:        ttl,
+	}, nil
+}
+
+// Get returns the value associated with the key, or an error if not found.
+func (d *Cache[T]) Get(ctx context.Context, key string) (T, error) {
+	var zero T
+	item, err := d.daprClient.GetState(ctx, d.cacheName, ctxUtils.CreateCacheKey(ctx, key), nil)
+	if err != nil {
+		return zero, err
+	}
+	if item == nil || len(item.Value) == 0 {
+		return zero, cache.ErrNotFound
+	}
+
+	var value T
+	if err := json.Unmarshal(item.Value, &value); err != nil {
+		return zero, fmt.Errorf("failed to unmarshal cached value: %w", err)
+	}
+	return value, nil
+}
+
+// Set stores a value with the specified key. A non-positive ttl falls back to
+// the cache's configured default TTL.
+func (d *Cache[T]) Set(ctx context.Context, key string, value T, ttl time.Duration) error {
+	if ttl <= 0 {
+		ttl = d.ttl
+	}
+
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("failed to marshal value for dapr cache: %w", err)
+	}
+
+	var md map[string]string
+	if ttl > 0 {
+		md = map[string]string{"ttlInSeconds": strconv.Itoa(int(ttl.Seconds()))}
+	}
+
+	if err := d.daprClient.SaveState(ctx, d.cacheName, ctxUtils.CreateCacheKey(ctx, key), bytes, md); err != nil {
+		return fmt.Errorf("failed to save value to dapr cache: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the specified key/value from the cache.
+func (d *Cache[T]) Delete(ctx context.Context, key string) error {
+	if err := d.daprClient.DeleteState(ctx, d.cacheName, ctxUtils.CreateCacheKey(ctx, key), nil); err != nil {
+		return fmt.Errorf("failed to delete value from dapr cache: %w", err)
+	}
+	return nil
+}

--- a/internal/cache/dapr/dapr_test.go
+++ b/internal/cache/dapr/dapr_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dapr
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dapr/go-sdk/client"
+	"github.com/notaryproject/ratify/v2/internal/cache"
+)
+
+const (
+	testCacheName = "test-cache"
+	testKey       = "test_key"
+	testValue     = "test_value"
+)
+
+// testDaprClient is a stub implementation of stateClient for unit tests.
+type testDaprClient struct {
+	stateValues map[string]string
+	throwError  error
+	mdValues    map[string]string
+}
+
+func (d *testDaprClient) GetState(_ context.Context, _, key string, _ map[string]string) (*client.StateItem, error) {
+	if d.throwError != nil {
+		return nil, d.throwError
+	}
+	value, ok := d.stateValues[key]
+	if !ok {
+		return &client.StateItem{Key: key}, nil
+	}
+	return &client.StateItem{
+		Key:   key,
+		Value: []byte(value),
+	}, nil
+}
+
+func (d *testDaprClient) SaveState(_ context.Context, _, key string, value []byte, md map[string]string, _ ...client.StateOption) error {
+	if d.throwError != nil {
+		return d.throwError
+	}
+	d.stateValues[key] = string(value)
+	d.mdValues = md
+	return nil
+}
+
+func (d *testDaprClient) DeleteState(_ context.Context, _, key string, _ map[string]string) error {
+	if d.throwError != nil {
+		return d.throwError
+	}
+	delete(d.stateValues, key)
+	return nil
+}
+
+func TestDaprCache_Get_Expected(t *testing.T) {
+	marshalled, _ := json.Marshal(testValue)
+	d := &Cache[string]{
+		daprClient: &testDaprClient{
+			stateValues: map[string]string{
+				testKey: string(marshalled),
+			},
+		},
+		cacheName: testCacheName,
+	}
+	val, err := d.Get(context.Background(), testKey)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if val != testValue {
+		t.Errorf("expected value to be %s, got %s", testValue, val)
+	}
+}
+
+func TestDaprCache_Get_NotFound(t *testing.T) {
+	d := &Cache[string]{
+		daprClient: &testDaprClient{
+			stateValues: map[string]string{},
+		},
+		cacheName: testCacheName,
+	}
+	_, err := d.Get(context.Background(), testKey)
+	if !errors.Is(err, cache.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDaprCache_Get_Error(t *testing.T) {
+	d := &Cache[string]{
+		daprClient: &testDaprClient{
+			throwError: fmt.Errorf("test error"),
+		},
+		cacheName: testCacheName,
+	}
+	if _, err := d.Get(context.Background(), testKey); err == nil {
+		t.Errorf("expected an error, got nil")
+	}
+}
+
+func TestDaprCache_Set_Expected(t *testing.T) {
+	d := &Cache[string]{
+		daprClient: &testDaprClient{
+			stateValues: map[string]string{},
+		},
+		cacheName: testCacheName,
+	}
+	if err := d.Set(context.Background(), testKey, testValue, 0); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	rawJSON := d.daprClient.(*testDaprClient).stateValues[testKey]
+	var value string
+	if err := json.Unmarshal([]byte(rawJSON), &value); err != nil {
+		t.Fatalf("expected valid json, got %v", err)
+	}
+	if value != testValue {
+		t.Errorf("expected value to be %s, got %s", testValue, value)
+	}
+}
+
+func TestDaprCache_Set_Error(t *testing.T) {
+	d := &Cache[string]{
+		daprClient: &testDaprClient{
+			throwError: fmt.Errorf("test error"),
+		},
+		cacheName: testCacheName,
+	}
+	if err := d.Set(context.Background(), testKey, testValue, 0); err == nil {
+		t.Errorf("expected an error, got nil")
+	}
+}
+
+func TestDaprCache_Set_WithTTL(t *testing.T) {
+	d := &Cache[string]{
+		daprClient: &testDaprClient{
+			stateValues: map[string]string{},
+		},
+		cacheName: testCacheName,
+	}
+	if err := d.Set(context.Background(), testKey, testValue, 10*time.Second); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	rawJSON := d.daprClient.(*testDaprClient).stateValues[testKey]
+	var value string
+	if err := json.Unmarshal([]byte(rawJSON), &value); err != nil {
+		t.Fatalf("expected valid json, got %v", err)
+	}
+	if value != testValue {
+		t.Errorf("expected value to be %s, got %s", testValue, value)
+	}
+	if d.daprClient.(*testDaprClient).mdValues["ttlInSeconds"] != "10" {
+		t.Errorf("expected ttlInSeconds to be 10, got %s", d.daprClient.(*testDaprClient).mdValues["ttlInSeconds"])
+	}
+}
+
+func TestDaprCache_Set_DefaultTTL(t *testing.T) {
+	d := &Cache[string]{
+		daprClient: &testDaprClient{
+			stateValues: map[string]string{},
+		},
+		cacheName: testCacheName,
+		ttl:       30 * time.Second,
+	}
+	if err := d.Set(context.Background(), testKey, testValue, 0); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if d.daprClient.(*testDaprClient).mdValues["ttlInSeconds"] != "30" {
+		t.Errorf("expected default ttlInSeconds to be 30, got %s", d.daprClient.(*testDaprClient).mdValues["ttlInSeconds"])
+	}
+}
+
+func TestDaprCache_Delete_Expected(t *testing.T) {
+	d := &Cache[string]{
+		daprClient: &testDaprClient{
+			stateValues: map[string]string{
+				testKey: testValue,
+			},
+		},
+		cacheName: testCacheName,
+	}
+	if err := d.Delete(context.Background(), testKey); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, ok := d.daprClient.(*testDaprClient).stateValues[testKey]; ok {
+		t.Errorf("expected key to be deleted")
+	}
+}
+
+func TestDaprCache_Delete_Error(t *testing.T) {
+	d := &Cache[string]{
+		daprClient: &testDaprClient{
+			throwError: fmt.Errorf("test error"),
+		},
+		cacheName: testCacheName,
+	}
+	if err := d.Delete(context.Background(), testKey); err == nil {
+		t.Errorf("expected an error, got nil")
+	}
+}

--- a/internal/cache/dapr/dapr_test.go
+++ b/internal/cache/dapr/dapr_test.go
@@ -186,6 +186,21 @@ func TestDaprCache_Set_DefaultTTL(t *testing.T) {
 	}
 }
 
+func TestDaprCache_Set_SubSecondTTL(t *testing.T) {
+	d := &Cache[string]{
+		daprClient: &testDaprClient{
+			stateValues: map[string]string{},
+		},
+		cacheName: testCacheName,
+	}
+	if err := d.Set(context.Background(), testKey, testValue, 500*time.Millisecond); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := d.daprClient.(*testDaprClient).mdValues["ttlInSeconds"]; got != "1" {
+		t.Errorf("expected sub-second TTL to round up to 1, got %s", got)
+	}
+}
+
 func TestDaprCache_Delete_Expected(t *testing.T) {
 	d := &Cache[string]{
 		daprClient: &testDaprClient{

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -28,11 +28,13 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/notaryproject/ratify/v2/internal/cache"
+	"github.com/notaryproject/ratify/v2/internal/cache/dapr"
 	"github.com/notaryproject/ratify/v2/internal/cache/ristretto"
 	"github.com/notaryproject/ratify/v2/internal/controller"
 	"github.com/notaryproject/ratify/v2/internal/executor"
 	"github.com/notaryproject/ratify/v2/internal/httpserver/config"
 	"github.com/notaryproject/ratify/v2/internal/httpserver/tlssecret"
+	"github.com/notaryproject/ratify/v2/pkg/featureflag"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 )
@@ -136,11 +138,11 @@ func newServer(serverOpts *ServerOptions, executorConfigPath string) (*server, *
 		getExecutorFunc = controller.GlobalExecutorManager.GetExecutor
 	}
 
-	mutateCache, err := ristretto.NewCache[string](defaultCacheTTL)
+	mutateCache, err := newCache[string](defaultCacheTTL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create mutate cache: %w", err)
 	}
-	verifyCache, err := ristretto.NewCache[*result](defaultCacheTTL)
+	verifyCache, err := newCache[*result](defaultCacheTTL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create verify cache: %w", err)
 	}
@@ -164,6 +166,17 @@ func newServer(serverOpts *ServerOptions, executorConfigPath string) (*server, *
 		return nil, nil, fmt.Errorf("failed to register handlers: %w", err)
 	}
 	return server, configWatcher, nil
+}
+
+// newCache creates a cache for the server. When the high-availability feature
+// flag is enabled it returns a distributed Dapr-backed cache so that state is
+// shared across replicas; otherwise it falls back to the in-process Ristretto
+// cache.
+func newCache[T any](ttl time.Duration) (cache.Cache[T], error) {
+	if featureflag.HighAvailability.Enabled {
+		return dapr.NewCache[T](dapr.DefaultCacheName, ttl)
+	}
+	return ristretto.NewCache[T](ttl)
 }
 
 func (s *server) registerHandlers() error {


### PR DESCRIPTION
## Description

Ports the Dapr cache provider from Ratify v1 (`pkg/cache/dapr`) to v2, enabling the high-availability deployment mode where verify/mutate cache state is shared across replicas via a Dapr state store.

### Changes
- **`internal/cache/dapr`**: new provider implementing the generic `cache.Cache[T]` interface. Values are JSON-encoded so any `T` can be shared across replicas. Keys are namespaced via `internal/context.CreateCacheKey`, and construction is gated by the `EXPERIMENTAL_HIGH_AVAILABILITY` feature flag.
  - v1's separate `Set`/`SetWithTTL` are merged into a single `Set(ctx, key, value, ttl)` to match the v2 Ristretto/in-memory providers; a non-positive TTL falls back to the configured default.
  - `Get` returns `cache.ErrNotFound` when the state entry is empty, honoring the v2 cache contract.
- **`internal/httpserver`**: cache creation now goes through a `newCache[T]` helper that returns the Dapr cache when high-availability is enabled, otherwise Ristretto. Default behavior is unchanged.
- Adds the `github.com/dapr/go-sdk` dependency and unit tests mirroring the v1 coverage.

### Testing
- `go build ./...`
- `go test ./internal/cache/... ./internal/httpserver/...` — all pass
- `golangci-lint` on the new package — 0 issues

> Note: the high-availability path is inert unless `RATIFY_EXPERIMENTAL_HIGH_AVAILABILITY=1` and a Dapr sidecar are present, so default deployments are unaffected.
