### PR TITLE
test: fix AKS e2e leaf cert test by running leaf-cert setup

### DIFF
--- a/scripts/azure-ci-test.sh
+++ b/scripts/azure-ci-test.sh
@@ -175,7 +175,13 @@ main() {
   # the signed image with the ratify-bats-test certificate. This replaces the
   # v1 `make e2e-azure-setup` (which also provisioned the cosign key and KMP
   # inputs); the full setup returns once those verifiers land in v2.
-  make e2e-create-all-image e2e-notation-setup \
+  #
+  # e2e-notation-leaf-cert-setup generates the leaf-test cert chain under
+  # ~/.config/notation/truststore/x509/ca/leaf-test (root.crt/leaf.crt) and
+  # pushes the notation:leafSigned image, both of which the
+  # "validate image signed by leaf cert" bats case depends on. It must run
+  # after e2e-notation-setup, which creates ~/.config/notation/signingkeys.json.
+  make e2e-create-all-image e2e-notation-setup e2e-notation-leaf-cert-setup \
     TEST_REGISTRY=$REGISTRY \
     TEST_REGISTRY_USERNAME=${ACR_USER_NAME} \
     TEST_REGISTRY_PASSWORD=${ACR_PASSWORD}


### PR DESCRIPTION
This PR is a test fix. It does not need to be merged, or you may close it directly.

## What

The AKS e2e job (`e2e-aks` → `scripts/azure-ci-test.sh`) fails on test 2, `validate image signed by leaf cert`:

```
not ok 2 validate image signed by leaf cert
# output: cat: /home/runner/.config/notation/truststore/x509/ca/leaf-test/root.crt: No such file or directory
```

Example failing run: https://github.com/notaryproject/ratify/actions/runs/30964612496/job/92175788505

## Root cause

The bats case reads the generated leaf-test cert chain from `~/.config/notation/truststore/x509/ca/leaf-test/{root,leaf}.crt` and runs the `notation:leafSigned` image. Those artifacts are produced by the `e2e-notation-leaf-cert-setup` Makefile target, but `azure-ci-test.sh` `main()` only ran `e2e-create-all-image e2e-notation-setup` — it never ran `e2e-notation-leaf-cert-setup`. So `root.crt` was never created and the image was never pushed, causing the test to fail.

## Fix

Add `e2e-notation-leaf-cert-setup` to the `make` invocation in `scripts/azure-ci-test.sh`, ordered after `e2e-notation-setup` (which creates `~/.config/notation/signingkeys.json` that the leaf setup appends to).

No production code changed — CI/test setup only.