### PR TITLE
feat: log registry store operations

### DIFF
--- a/internal/store/registrystore/logging.go
+++ b/internal/store/registrystore/logging.go
@@ -1,0 +1,87 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registrystore
+
+import (
+	"context"
+	"time"
+
+	"github.com/notaryproject/ratify-go"
+	"github.com/notaryproject/ratify/v2/internal/logger"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+var logOpt = logger.Option{ComponentType: logger.ReferrerStore}
+
+// loggingStore reports every registry operation the executor performs.
+// ratify-go's RegistryStore is deliberately dependency-free and does not log, so
+// without this wrapper a slow or failing registry call leaves no trace at all.
+type loggingStore struct {
+	inner ratify.Store
+}
+
+func (s *loggingStore) Resolve(ctx context.Context, ref string) (ocispec.Descriptor, error) {
+	log := logger.GetLogger(ctx, logOpt)
+	start := time.Now()
+	desc, err := s.inner.Resolve(ctx, ref)
+	if err != nil {
+		log.Errorf("failed to resolve %s after %dms: %v", ref, time.Since(start).Milliseconds(), err)
+		return desc, err
+	}
+	log.Debugf("resolved %s to %s in %dms", ref, desc.Digest, time.Since(start).Milliseconds())
+	return desc, nil
+}
+
+func (s *loggingStore) ListReferrers(ctx context.Context, ref string, artifactTypes []string, fn func(referrers []ocispec.Descriptor) error) error {
+	log := logger.GetLogger(ctx, logOpt)
+	start := time.Now()
+	// ListReferrers paginates, so the total is only known once fn stops being called.
+	count := 0
+	err := s.inner.ListReferrers(ctx, ref, artifactTypes, func(referrers []ocispec.Descriptor) error {
+		count += len(referrers)
+		return fn(referrers)
+	})
+	if err != nil {
+		log.Errorf("failed to list referrers for %s after %dms: %v", ref, time.Since(start).Milliseconds(), err)
+		return err
+	}
+	log.Debugf("listed %d referrer(s) for %s in %dms", count, ref, time.Since(start).Milliseconds())
+	return nil
+}
+
+func (s *loggingStore) FetchBlob(ctx context.Context, repo string, desc ocispec.Descriptor) ([]byte, error) {
+	log := logger.GetLogger(ctx, logOpt)
+	start := time.Now()
+	blob, err := s.inner.FetchBlob(ctx, repo, desc)
+	if err != nil {
+		log.Errorf("failed to fetch blob %s from %s after %dms: %v", desc.Digest, repo, time.Since(start).Milliseconds(), err)
+		return nil, err
+	}
+	log.Debugf("fetched blob %s (%s, %d bytes) from %s in %dms", desc.Digest, desc.MediaType, len(blob), repo, time.Since(start).Milliseconds())
+	return blob, nil
+}
+
+func (s *loggingStore) FetchManifest(ctx context.Context, repo string, desc ocispec.Descriptor) ([]byte, error) {
+	log := logger.GetLogger(ctx, logOpt)
+	start := time.Now()
+	manifest, err := s.inner.FetchManifest(ctx, repo, desc)
+	if err != nil {
+		log.Errorf("failed to fetch manifest %s from %s after %dms: %v", desc.Digest, repo, time.Since(start).Milliseconds(), err)
+		return nil, err
+	}
+	log.Debugf("fetched manifest %s (%s, %d bytes) from %s in %dms", desc.Digest, desc.MediaType, len(manifest), repo, time.Since(start).Milliseconds())
+	return manifest, nil
+}

--- a/internal/store/registrystore/logging_test.go
+++ b/internal/store/registrystore/logging_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registrystore
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+type stubStore struct {
+	desc      ocispec.Descriptor
+	referrers [][]ocispec.Descriptor
+	payload   []byte
+	err       error
+}
+
+func (s *stubStore) Resolve(_ context.Context, _ string) (ocispec.Descriptor, error) {
+	return s.desc, s.err
+}
+
+func (s *stubStore) ListReferrers(_ context.Context, _ string, _ []string, fn func([]ocispec.Descriptor) error) error {
+	if s.err != nil {
+		return s.err
+	}
+	for _, page := range s.referrers {
+		if err := fn(page); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *stubStore) FetchBlob(_ context.Context, _ string, _ ocispec.Descriptor) ([]byte, error) {
+	return s.payload, s.err
+}
+
+func (s *stubStore) FetchManifest(_ context.Context, _ string, _ ocispec.Descriptor) ([]byte, error) {
+	return s.payload, s.err
+}
+
+// findEntry returns the first entry at the given level whose message contains
+// want. The logrus hook is global, so tests match on their own message rather
+// than assuming they are the only writer.
+func findEntry(hook *test.Hook, level logrus.Level, want string) *logrus.Entry {
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == level && strings.Contains(entry.Message, want) {
+			return entry
+		}
+	}
+	return nil
+}
+
+func newHook(t *testing.T) *test.Hook {
+	t.Helper()
+	base := logrus.StandardLogger()
+	previous := base.GetLevel()
+	base.SetLevel(logrus.DebugLevel)
+	hook := test.NewLocal(base)
+	t.Cleanup(func() {
+		base.SetLevel(previous)
+		hook.Reset()
+	})
+	return hook
+}
+
+func TestLoggingStore_Resolve(t *testing.T) {
+	hook := newHook(t)
+	store := &loggingStore{inner: &stubStore{desc: ocispec.Descriptor{Digest: "sha256:abc"}}}
+
+	desc, err := store.Resolve(context.Background(), "registry.example/app:v1")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if desc.Digest != "sha256:abc" {
+		t.Errorf("Resolve() digest = %s, want sha256:abc", desc.Digest)
+	}
+	if findEntry(hook, logrus.DebugLevel, "resolved registry.example/app:v1 to sha256:abc") == nil {
+		t.Error("expected the resolved digest to be logged at debug level")
+	}
+}
+
+func TestLoggingStore_ResolveError(t *testing.T) {
+	hook := newHook(t)
+	store := &loggingStore{inner: &stubStore{err: errors.New("manifest unknown")}}
+
+	if _, err := store.Resolve(context.Background(), "registry.example/app:v1"); err == nil {
+		t.Fatal("expected the underlying error to be returned")
+	}
+	if findEntry(hook, logrus.ErrorLevel, "failed to resolve registry.example/app:v1") == nil {
+		t.Error("expected the resolve failure to be logged at error level")
+	}
+}
+
+// The referrer count is only known after pagination finishes, so it must be
+// accumulated across every callback rather than taken from the first page.
+func TestLoggingStore_ListReferrersCountsAllPages(t *testing.T) {
+	hook := newHook(t)
+	store := &loggingStore{inner: &stubStore{referrers: [][]ocispec.Descriptor{
+		{{Digest: "sha256:1"}, {Digest: "sha256:2"}},
+		{{Digest: "sha256:3"}},
+	}}}
+
+	var seen int
+	err := store.ListReferrers(context.Background(), "registry.example/app:v1", nil, func(referrers []ocispec.Descriptor) error {
+		seen += len(referrers)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ListReferrers() error = %v", err)
+	}
+	if seen != 3 {
+		t.Errorf("caller received %d referrer(s), want 3", seen)
+	}
+	if findEntry(hook, logrus.DebugLevel, "listed 3 referrer(s)") == nil {
+		t.Error("expected the total referrer count across pages to be logged")
+	}
+}
+
+func TestLoggingStore_ListReferrersError(t *testing.T) {
+	hook := newHook(t)
+	store := &loggingStore{inner: &stubStore{err: errors.New("referrers not supported")}}
+
+	err := store.ListReferrers(context.Background(), "registry.example/app:v1", nil, func([]ocispec.Descriptor) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected the underlying error to be returned")
+	}
+	if findEntry(hook, logrus.ErrorLevel, "failed to list referrers") == nil {
+		t.Error("expected the list failure to be logged at error level")
+	}
+}
+
+func TestLoggingStore_FetchBlob(t *testing.T) {
+	hook := newHook(t)
+	store := &loggingStore{inner: &stubStore{payload: []byte("signature")}}
+
+	blob, err := store.FetchBlob(context.Background(), "registry.example/app", ocispec.Descriptor{
+		Digest:    "sha256:blob",
+		MediaType: "application/octet-stream",
+	})
+	if err != nil {
+		t.Fatalf("FetchBlob() error = %v", err)
+	}
+	if string(blob) != "signature" {
+		t.Errorf("FetchBlob() = %q, want %q", blob, "signature")
+	}
+	entry := findEntry(hook, logrus.DebugLevel, "fetched blob sha256:blob")
+	if entry == nil {
+		t.Fatal("expected the blob fetch to be logged at debug level")
+	}
+	if !strings.Contains(entry.Message, "9 bytes") {
+		t.Errorf("expected the blob size in the message, got: %s", entry.Message)
+	}
+}
+
+func TestLoggingStore_FetchBlobError(t *testing.T) {
+	hook := newHook(t)
+	store := &loggingStore{inner: &stubStore{err: errors.New("blob unknown")}}
+
+	if _, err := store.FetchBlob(context.Background(), "registry.example/app", ocispec.Descriptor{Digest: "sha256:blob"}); err == nil {
+		t.Fatal("expected the underlying error to be returned")
+	}
+	if findEntry(hook, logrus.ErrorLevel, "failed to fetch blob sha256:blob") == nil {
+		t.Error("expected the blob failure to be logged at error level")
+	}
+}
+
+func TestLoggingStore_FetchManifest(t *testing.T) {
+	hook := newHook(t)
+	store := &loggingStore{inner: &stubStore{payload: []byte(`{"schemaVersion":2}`)}}
+
+	manifest, err := store.FetchManifest(context.Background(), "registry.example/app", ocispec.Descriptor{
+		Digest:    "sha256:manifest",
+		MediaType: ocispec.MediaTypeImageManifest,
+	})
+	if err != nil {
+		t.Fatalf("FetchManifest() error = %v", err)
+	}
+	if string(manifest) != `{"schemaVersion":2}` {
+		t.Errorf("FetchManifest() = %q", manifest)
+	}
+	if findEntry(hook, logrus.DebugLevel, "fetched manifest sha256:manifest") == nil {
+		t.Error("expected the manifest fetch to be logged at debug level")
+	}
+}
+
+func TestLoggingStore_FetchManifestError(t *testing.T) {
+	hook := newHook(t)
+	store := &loggingStore{inner: &stubStore{err: errors.New("manifest unknown")}}
+
+	if _, err := store.FetchManifest(context.Background(), "registry.example/app", ocispec.Descriptor{Digest: "sha256:manifest"}); err == nil {
+		t.Fatal("expected the underlying error to be returned")
+	}
+	if findEntry(hook, logrus.ErrorLevel, "failed to fetch manifest sha256:manifest") == nil {
+		t.Error("expected the manifest failure to be logged at error level")
+	}
+}

--- a/internal/store/registrystore/register.go
+++ b/internal/store/registrystore/register.go
@@ -131,6 +131,6 @@ func init() {
 			CredentialProvider: credProvider,
 		}
 
-		return ratify.NewRegistryStore(registryStoreOpts), nil
+		return &loggingStore{inner: ratify.NewRegistryStore(registryStoreOpts)}, nil
 	})
 }


### PR DESCRIPTION
## Description

Closes the last in-repo logging blind spot on the verification path: **every registry round trip is currently invisible.**

`internal/store/registrystore` only builds a `ratify-go` `RegistryStore`, and that library is deliberately dependency-free — [COMPUTED] it has **zero log calls in the entire module**, which is reasonable for a library. The consequence is that a slow `ListReferrers`, a manifest fetch that 404s, or a blob pull that times out leaves no trace on the server at all. The operator sees only the final "verification failed" with no idea which registry call was responsible.

> [!NOTE]
> In #2877 I claimed this "cannot be added from this repo" and would need an upstream issue. That was wrong, and I've [posted a correction there](https://github.com/notaryproject/ratify/pull/2877). `ratify.Store` is an *interface*, and our factory already returns it, so the seam is local. No upstream change is needed.

### Change

`ratify.Store` has four methods, and `internal/store/registrystore` already returns that interface from its factory:

```go
type Store interface {
	Resolve(ctx, ref) (ocispec.Descriptor, error)
	ListReferrers(ctx, ref, artifactTypes, fn) error
	FetchBlob(ctx, repo, desc) ([]byte, error)
	FetchManifest(ctx, repo, desc) ([]byte, error)
}
```

So the store is wrapped in a decorator rather than changing the dependency:

```go
return &loggingStore{inner: ratify.NewRegistryStore(registryStoreOpts)}, nil
```

Each operation now logs:

- **`debug`** on success — the resolved digest, the referrer count, the blob/manifest digest with media type and size, and the duration in ms.
- **`error`** on failure — the reference or digest, the duration, and the error.

`ListReferrers` paginates, so the referrer count is accumulated across every callback rather than taken from the first page.

Logging goes through `internal/logger`, so entries carry the request **trace ID** and `component-type=referrerStore`. That correlation is the main reason this belongs here rather than upstream: `ratify-go` has no concept of the request context Ratify attaches.

Example output that previously did not exist at all:

```
level=debug msg="resolved registry.example/app:v1 to sha256:abc… in 42ms" component-type=referrerStore trace-id=0d9a6926-…
level=debug msg="listed 3 referrer(s) for registry.example/app:v1 in 88ms" component-type=referrerStore trace-id=0d9a6926-…
level=debug msg="fetched blob sha256:def… (application/vnd.cncf.notary.signature, 2048 bytes) from registry.example/app in 15ms" component-type=referrerStore trace-id=0d9a6926-…
level=error msg="failed to fetch manifest sha256:123… from registry.example/app after 5001ms: context deadline exceeded" component-type=referrerStore trace-id=0d9a6926-…
```

No credentials, tokens or blob contents are logged — only references, digests, media types, sizes and durations.

### Testing

- New `logging_test.go` drives every method through a stub `ratify.Store` on both the success and failure paths. `internal/store/registrystore` is at **100% statement coverage**.
- `TestLoggingStore_ListReferrersCountsAllPages` specifically covers the pagination accumulation, and asserts the wrapped callback still forwards every page to the caller.
- Log assertions match on the test's own message via a `findEntry` helper rather than on log level alone, so a shared hook cannot make them pass spuriously.
- `go build ./...`, `go vet`, package tests and `golangci-lint` pass. No `go.mod` change.

Additive logging only; the decorator returns the inner store's values and errors unchanged.

Enable with `--set logger.level=debug` (#2846).
