### PR TITLE
fix: do not compare against empty string to inject `azure.workload.id/use` label

### DIFF
--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         {{- include "ratify.podLabels" . | nindent 8 }}
         {{- include "ratify.selectorLabels" . | nindent 8 }}
-        {{- if ne .Values.azureWorkloadIdentity.clientId "" }}
+        {{- if .Values.azureWorkloadIdentity.clientId }}
         azure.workload.identity/use: "true"
         {{- end }}
       annotations:


### PR DESCRIPTION
## Description

Normalize the if condition to inject the `azure.workload.identity/use` label between the `Deployment` resource and the `ServiceAccount` resource. Without this fix, the `azure.workload.identity/use` gets injected unconditionally because the default value of `.Values.azureWorkloadIdentity.clientId` is null.

### Which issue(s) does this PR resolve?

<!--
    Use `Fixes #<issue number>[, Fixes #<issue_number>, ...]` format.
    Use `Fixes` for bug fixes and `Resolves` for new features.
    The PR will close the issue(s) when it gets merged.
-->
Fixes #2902

### Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## Testing and verification

`helm template` before:
```
$ helm template ratify ratify -f ratify/values.yaml | k kfilt -i k=Deployment | yq .spec.template.metadata.labels
app.kubernetes.io/instance: ratify
app.kubernetes.io/name: ratify
azure.workload.identity/use: "true"
```

`helm template` after:
```
$ helm template ratify ratify -f ratify/values.yaml | k kfilt -i k=Deployment | yq .spec.template.metadata.labels
app.kubernetes.io/instance: ratify
app.kubernetes.io/name: ratify
```

`helm template` with a non-null value of `.Values.azureWorkloadIdentity.clientId` after:
```
$ cat ratify/values.yaml | yq .azureWorkloadIdentity
clientId: "hello"

$ helm template ratify ratify -f ratify/values.yaml | k kfilt -i k=Deployment | yq .spec.template.metadata.labels
app.kubernetes.io/instance: ratify
app.kubernetes.io/name: ratify
azure.workload.identity/use: "true"
```

## Checklist

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

## Post merge requirements

- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
