### PR TITLE
fix: do not compare against empty string to inject `azure.workload.id/use` label

### DIFF
--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         {{- include "ratify.podLabels" . | nindent 8 }}
         {{- include "ratify.selectorLabels" . | nindent 8 }}
-        {{- if ne .Values.azureWorkloadIdentity.clientId "" }}
+        {{- if .Values.azureWorkloadIdentity.clientId }}
         azure.workload.identity/use: "true"
         {{- end }}
       annotations:


### PR DESCRIPTION
Backport of https://github.com/notaryproject/ratify/pull/2903 into the `release-1.4` branch.

cc @fseldow 