### PR TITLE
ci: validate published image before chart publish

### DIFF
--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -4,6 +4,28 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
+    inputs:
+      k8s_version:
+        description: "Kubernetes version"
+        required: true
+        default: "1.31.2"
+        type: string
+      gatekeeper_version:
+        description: "Gatekeeper version"
+        required: true
+        default: "3.18.0"
+        type: string
+      ratify_image_repository:
+        description: "Ratify image repository used by the Helm chart"
+        required: false
+        default: "localbuild"
+        type: string
+      ratify_image_tag:
+        description: "Ratify image tag used by the Helm chart"
+        required: false
+        default: "test"
+        type: string
   workflow_call:
     inputs:
       k8s_version:
@@ -15,6 +37,16 @@ on:
         description: "Gatekeeper version"
         required: true
         default: "3.18.0"
+        type: string
+      ratify_image_repository:
+        description: "Ratify image repository used by the Helm chart"
+        required: false
+        default: "localbuild"
+        type: string
+      ratify_image_tag:
+        description: "Ratify image tag used by the Helm chart"
+        required: false
+        default: "test"
         type: string
 
 jobs:
@@ -47,7 +79,10 @@ jobs:
       - name: Run e2e with config policy
         run: |
           make e2e-deploy-gatekeeper GATEKEEPER_VERSION=${{ inputs.gatekeeper_version }}
-          make e2e-deploy-ratify GATEKEEPER_VERSION=${{ inputs.gatekeeper_version }}
+          make e2e-deploy-ratify \
+            GATEKEEPER_VERSION="${{ inputs.gatekeeper_version }}" \
+            E2E_RATIFY_IMAGE_REPOSITORY="${{ inputs.ratify_image_repository }}" \
+            E2E_RATIFY_IMAGE_TAG="${{ inputs.ratify_image_tag }}"
           make test-e2e GATEKEEPER_VERSION=${{ inputs.gatekeeper_version }}
       - name: Save logs
         if: ${{ always() }}
@@ -61,10 +96,10 @@ jobs:
       - name: Save logs
         if: ${{ always() }}
         run: |
-          kubectl logs -n gatekeeper-system -l control-plane=controller-manager --tail=-1 > logs-externaldata-controller-${{ matrix.KUBERNETES_VERSION }}-${{ matrix.GATEKEEPER_VERSION }}.json
-          kubectl logs -n gatekeeper-system -l control-plane=audit-controller --tail=-1 > logs-externaldata-audit-${{ matrix.KUBERNETES_VERSION }}-${{ matrix.GATEKEEPER_VERSION }}.json
-          kubectl logs -n gatekeeper-system -l app=ratify --tail=-1 > logs-ratify-preinstall-${{ matrix.KUBERNETES_VERSION }}-${{ matrix.GATEKEEPER_VERSION }}-rego-policy.json
-          kubectl logs -n gatekeeper-system -l app.kubernetes.io/name=ratify --tail=-1 > logs-ratify-${{ matrix.KUBERNETES_VERSION }}-${{ matrix.GATEKEEPER_VERSION }}-rego-policy.json
+          kubectl logs -n gatekeeper-system -l control-plane=controller-manager --tail=-1 > logs-externaldata-controller-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}.json
+          kubectl logs -n gatekeeper-system -l control-plane=audit-controller --tail=-1 > logs-externaldata-audit-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}.json
+          kubectl logs -n gatekeeper-system -l app=ratify --tail=-1 > logs-ratify-preinstall-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}-rego-policy.json
+          kubectl logs -n gatekeeper-system -l app.kubernetes.io/name=ratify --tail=-1 > logs-ratify-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}-rego-policy.json
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}

--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -1,8 +1,6 @@
 name: publishChart
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,4 +1,4 @@
-name: publish-ghcr
+name: publish-ghcr-and-chart
 
 on:
   push:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -11,6 +11,10 @@ permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.prepare.outputs.ref }}
+      image_repository: ${{ steps.prepare.outputs.repository }}
+      image_tag: ${{ steps.prepare.outputs.version }}
     permissions:
       packages: write
       contents: read
@@ -53,10 +57,11 @@ jobs:
           if [[ "${VERSION}" == "${BRANCH_NAME}" ]]; then
             VERSION=$(git rev-parse --short HEAD)
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=ref::${REPOSITORY}:${VERSION}
-          echo ::set-output name=baseref::${REPOSITORYBASE}:${VERSION}
-          echo ::set-output name=crdref::${REPOSITORYCRD}:${VERSION}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "repository=${REPOSITORY}" >> $GITHUB_OUTPUT
+          echo "ref=${REPOSITORY}:${VERSION}" >> $GITHUB_OUTPUT
+          echo "baseref=${REPOSITORYBASE}:${VERSION}" >> $GITHUB_OUTPUT
+          echo "crdref=${REPOSITORYCRD}:${VERSION}" >> $GITHUB_OUTPUT
       - name: Get tag
         run: |
           echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
@@ -152,3 +157,37 @@ jobs:
         if: always()
         run: |
           rm -f ${HOME}/.docker/config.json
+
+  e2e:
+    name: Run e2e with published image and current chart
+    needs: build
+    uses: ./.github/workflows/e2e-k8s.yml
+    with:
+      k8s_version: "1.31.2"
+      gatekeeper_version: "3.18.0"
+      ratify_image_repository: ${{ needs.build.outputs.image_repository }}
+      ratify_image_tag: ${{ needs.build.outputs.image_tag }}
+
+  publish-chart:
+    name: Publish Helm charts
+    needs: e2e
+    runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.prepare.outputs.ref }}
+      image_repository: ${{ steps.prepare.outputs.repository }}
+      image_tag: ${{ steps.prepare.outputs.version }}
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -172,10 +172,6 @@ jobs:
     name: Publish Helm charts
     needs: e2e
     runs-on: ubuntu-latest
-    outputs:
-      image_ref: ${{ steps.prepare.outputs.ref }}
-      image_repository: ${{ steps.prepare.outputs.repository }}
-      image_tag: ${{ steps.prepare.outputs.version }}
     permissions:
       contents: write
     steps:

--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,20 @@ TRIVY_VERSION ?= 0.71.1
 GATEKEEPER_NAMESPACE = gatekeeper-system
 RATIFY_NAME = ratify
 
-# Image the e2e Helm deployment uses. Defaults to the locally built image
-# (localbuild:test) so existing local/e2e flows keep working, but can be
-# overridden (e.g. from the publish workflow) to validate a published image.
+# E2E Ratify Image Setup
+# Defaults to the locally built image (localbuild:test) so existing local/e2e
+# flows keep working. When overridden (e.g. from the publish workflow to a
+# published image), skip the local image build/load and pull the image instead
+# so the e2e run validates the real published artifact.
 E2E_RATIFY_IMAGE_REPOSITORY ?= localbuild
 E2E_RATIFY_IMAGE_TAG ?= test
+E2E_RATIFY_IMAGE_PULL_POLICY ?= Never
+BUILD_E2E_RATIFY_IMAGE ?= e2e-build-local-ratify-image load-local-ratify-image
+
+ifneq ($(E2E_RATIFY_IMAGE_REPOSITORY):$(E2E_RATIFY_IMAGE_TAG),localbuild:test)
+  E2E_RATIFY_IMAGE_PULL_POLICY = IfNotPresent
+  BUILD_E2E_RATIFY_IMAGE =
+endif
 
 TIMESTAMP_URL = http://timestamp.digicert.com
 
@@ -561,10 +570,10 @@ e2e-deploy-gatekeeper: e2e-helm-install
 	./.staging/helm/linux-amd64/helm install gatekeeper/gatekeeper --version ${GATEKEEPER_VERSION} --name-template=gatekeeper --namespace ${GATEKEEPER_NAMESPACE} --create-namespace --set enableExternalData=true --set validatingWebhookTimeoutSeconds=5 --set mutatingWebhookTimeoutSeconds=2 --set auditInterval=0 --set externaldataProviderResponseCacheTTL=1s
 
 e2e-build-crd-image:
-	docker build --progress=plain --no-cache --build-arg KUBE_VERSION=${KUBERNETES_VERSION} --build-arg TARGETOS="linux" --build-arg TARGETARCH="amd64" -f crd.Dockerfile -t localbuildcrd:test ./charts/ratify/crds	
+	docker build --progress=plain --no-cache --build-arg KUBE_VERSION=${KUBERNETES_VERSION} --build-arg TARGETOS="linux" --build-arg TARGETARCH="amd64" -f crd.Dockerfile -t localbuildcrd:${E2E_RATIFY_IMAGE_TAG} ./charts/ratify/crds	
 
 load-build-crd-image:
-	kind load docker-image --name kind localbuildcrd:test
+	kind load docker-image --name kind localbuildcrd:${E2E_RATIFY_IMAGE_TAG}
 
 e2e-deploy-base-ratify: e2e-notation-setup e2e-notation-leaf-cert-setup e2e-cosign-setup e2e-inlinecert-setup e2e-build-crd-image load-build-crd-image e2e-build-local-ratify-base-image
 	printf "{\n\t\"auths\": {\n\t\t\"registry:5000\": {\n\t\t\t\"auth\": \"`echo "${TEST_REGISTRY_USERNAME}:${TEST_REGISTRY_PASSWORD}" | tr -d '\n' | base64 -i -w 0`\"\n\t\t}\n\t}\n}" > mount_config.json
@@ -590,14 +599,7 @@ e2e-deploy-base-ratify: e2e-notation-setup e2e-notation-leaf-cert-setup e2e-cosi
 
 	rm mount_config.json
 
-e2e-deploy-ratify: e2e-notation-setup e2e-notation-leaf-cert-setup e2e-notation-crl-setup e2e-cosign-setup e2e-cosign-setup e2e-licensechecker-setup e2e-sbom-setup e2e-trivy-setup e2e-schemavalidator-setup e2e-vulnerabilityreport-setup e2e-inlinecert-setup e2e-build-crd-image load-build-crd-image
-	# Only build and load the local image when using the default localbuild
-	# repository. When a published image is requested, deploy that instead so
-	# the e2e run validates the real published artifact.
-	@if [ "${E2E_RATIFY_IMAGE_REPOSITORY}" = "localbuild" ]; then \
-		$(MAKE) e2e-build-local-ratify-image load-local-ratify-image; \
-	fi
-	$(MAKE) e2e-helm-deploy-ratify
+e2e-deploy-ratify: e2e-notation-setup e2e-notation-leaf-cert-setup e2e-notation-crl-setup e2e-cosign-setup e2e-cosign-setup e2e-licensechecker-setup e2e-sbom-setup e2e-trivy-setup e2e-schemavalidator-setup e2e-vulnerabilityreport-setup e2e-inlinecert-setup e2e-build-crd-image load-build-crd-image $(BUILD_E2E_RATIFY_IMAGE) e2e-helm-deploy-ratify
 
 e2e-build-local-ratify-base-image:
 	docker build --progress=plain --no-cache \
@@ -613,10 +615,10 @@ e2e-build-local-ratify-image:
 	--build-arg build_vulnerabilityreport=true \
 	--build-arg build_slsaverifier=true \
 	-f ./httpserver/Dockerfile \
-	-t localbuild:test .
+	-t ${E2E_RATIFY_IMAGE_REPOSITORY}:${E2E_RATIFY_IMAGE_TAG} .
 
 load-local-ratify-image:
-	kind load docker-image --name kind localbuild:test
+	kind load docker-image --name kind ${E2E_RATIFY_IMAGE_REPOSITORY}:${E2E_RATIFY_IMAGE_TAG}
 
 e2e-helmfile-deploy-released-ratify:
 	./.staging/helmfilebin/helmfile sync -f 'git::https://github.com/ratify-project/ratify.git@helmfile.yaml.gotmpl?ref=v1'
@@ -629,6 +631,7 @@ e2e-helm-deploy-ratify:
 	--set image.repository=${E2E_RATIFY_IMAGE_REPOSITORY} \
 	--set image.crdRepository=localbuildcrd \
 	--set image.tag=${E2E_RATIFY_IMAGE_TAG} \
+	--set image.pullPolicy=${E2E_RATIFY_IMAGE_PULL_POLICY} \
 	--set gatekeeper.version=${GATEKEEPER_VERSION} \
 	--set featureFlags.RATIFY_CERT_ROTATION=${CERT_ROTATION_ENABLED} \
 	--set-file provider.tls.crt=${CERT_DIR}/server.crt \

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,12 @@ TRIVY_VERSION ?= 0.71.1
 GATEKEEPER_NAMESPACE = gatekeeper-system
 RATIFY_NAME = ratify
 
+# Image the e2e Helm deployment uses. Defaults to the locally built image
+# (localbuild:test) so existing local/e2e flows keep working, but can be
+# overridden (e.g. from the publish workflow) to validate a published image.
+E2E_RATIFY_IMAGE_REPOSITORY ?= localbuild
+E2E_RATIFY_IMAGE_TAG ?= test
+
 TIMESTAMP_URL = http://timestamp.digicert.com
 
 # Local Registry Setup
@@ -584,7 +590,14 @@ e2e-deploy-base-ratify: e2e-notation-setup e2e-notation-leaf-cert-setup e2e-cosi
 
 	rm mount_config.json
 
-e2e-deploy-ratify: e2e-notation-setup e2e-notation-leaf-cert-setup e2e-notation-crl-setup e2e-cosign-setup e2e-cosign-setup e2e-licensechecker-setup e2e-sbom-setup e2e-trivy-setup e2e-schemavalidator-setup e2e-vulnerabilityreport-setup e2e-inlinecert-setup e2e-build-crd-image load-build-crd-image e2e-build-local-ratify-image load-local-ratify-image e2e-helm-deploy-ratify
+e2e-deploy-ratify: e2e-notation-setup e2e-notation-leaf-cert-setup e2e-notation-crl-setup e2e-cosign-setup e2e-cosign-setup e2e-licensechecker-setup e2e-sbom-setup e2e-trivy-setup e2e-schemavalidator-setup e2e-vulnerabilityreport-setup e2e-inlinecert-setup e2e-build-crd-image load-build-crd-image
+	# Only build and load the local image when using the default localbuild
+	# repository. When a published image is requested, deploy that instead so
+	# the e2e run validates the real published artifact.
+	@if [ "${E2E_RATIFY_IMAGE_REPOSITORY}" = "localbuild" ]; then \
+		$(MAKE) e2e-build-local-ratify-image load-local-ratify-image; \
+	fi
+	$(MAKE) e2e-helm-deploy-ratify
 
 e2e-build-local-ratify-base-image:
 	docker build --progress=plain --no-cache \
@@ -613,9 +626,9 @@ e2e-helm-deploy-ratify:
 
 	./.staging/helm/linux-amd64/helm install ${RATIFY_NAME} \
     ./charts/ratify --atomic --namespace ${GATEKEEPER_NAMESPACE} --create-namespace \
-	--set image.repository=localbuild \
+	--set image.repository=${E2E_RATIFY_IMAGE_REPOSITORY} \
 	--set image.crdRepository=localbuildcrd \
-	--set image.tag=test \
+	--set image.tag=${E2E_RATIFY_IMAGE_TAG} \
 	--set gatekeeper.version=${GATEKEEPER_VERSION} \
 	--set featureFlags.RATIFY_CERT_ROTATION=${CERT_ROTATION_ENABLED} \
 	--set-file provider.tls.crt=${CERT_DIR}/server.crt \


### PR DESCRIPTION
Cherry-picks the non-merge changes from #2739 onto v1-dev.

Notes:
- Backports the publish workflow change so Helm chart publishing waits for e2e validation against the newly published image.
- Keeps v1-dev workflow structure and chart path (`charts`) instead of reintroducing removed main-branch dev workflows.
- Skips the intermediate merge-from-main commit from the original PR branch.