### PR TITLE
chore: bump Go Docker image to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.23@sha256:e57c41c1d5864341031181b0db34b9a537bb5773eb6428e4e5bdaea0f9135406 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps the Go builder image in `Dockerfile` from 1.26.5-alpine3.23 to 1.26.6-alpine3.23 and updates the pinned digest.