### PR TITLE
chore: bump Go Docker image to 1.26.6

### DIFF
--- a/httpserver/Dockerfile
+++ b/httpserver/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6@sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6 AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS


### PR DESCRIPTION
Bumps the Go builder image in `httpserver/Dockerfile` from 1.26.5 to 1.26.6 and updates the pinned digest.