### PR TITLE
ci: allow configurable target branch input for CVE auto-bump CI

### DIFF
--- a/.github/workflows/cve-auto-bump.yml
+++ b/.github/workflows/cve-auto-bump.yml
@@ -22,12 +22,19 @@ jobs:
     steps:
       - name: Set matrix
         id: set-matrix
+        env:
+          TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
         run: |
-          TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
-          if [ -z "$TARGET_BRANCH" ]; then
-            TARGET_BRANCH="release-1.4"
+          BRANCH="${TARGET_BRANCH:-release-1.4}"
+          # Reject anything that is not a valid git ref name to avoid
+          # injecting unexpected values into the downstream matrix.
+          if ! printf '%s' "$BRANCH" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+            echo "::error::Invalid target branch name: '$BRANCH'"
+            exit 1
           fi
-          echo "branches=[\"$TARGET_BRANCH\"]" >> "$GITHUB_OUTPUT"
+          # Serialize with jq --arg so quotes/metacharacters cannot break the JSON.
+          BRANCHES=$(jq -cn --arg b "$BRANCH" '[$b]')
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
 
   cve-bump:
     name: "Scan CVEs and auto-bump (${{ matrix.branch }})"

--- a/.github/workflows/cve-auto-bump.yml
+++ b/.github/workflows/cve-auto-bump.yml
@@ -4,13 +4,34 @@ on:
   schedule:
     - cron: "0 0 * * *" # daily at 00:00 UTC
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "Target branch to scan and auto-bump"
+        required: false
+        default: "release-1.4"
 
 permissions:
   contents: read
 
 jobs:
+  setup:
+    name: "Resolve target branch"
+    runs-on: ubuntu-22.04
+    outputs:
+      branches: ${{ steps.set-matrix.outputs.branches }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
+          if [ -z "$TARGET_BRANCH" ]; then
+            TARGET_BRANCH="release-1.4"
+          fi
+          echo "branches=[\"$TARGET_BRANCH\"]" >> "$GITHUB_OUTPUT"
+
   cve-bump:
     name: "Scan CVEs and auto-bump (${{ matrix.branch }})"
+    needs: setup
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     permissions:
@@ -19,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.4]
+        branch: ${{ fromJSON(needs.setup.outputs.branches) }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
@@ -212,6 +233,8 @@ jobs:
         if: steps.vulncheck.outputs.has_vulns == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          sign-commits: true
+          signoff: true
           branch: security/cve-bump-${{ matrix.branch }}
           base: ${{ matrix.branch }}
           title: "chore: Bump vulnerable dependencies [${{ steps.vulncheck.outputs.cve_list }}]"
@@ -219,7 +242,6 @@ jobs:
             cve
             ${{ matrix.branch }}
           commit-message: "chore: bump vulnerable dependencies detected by govulncheck and trivy"
-          signoff: true
           body: |
             ## Security: Auto-bump vulnerable dependencies
 


### PR DESCRIPTION
## What this PR does

Makes the target branch for the `CVE Auto Bump` workflow configurable via `workflow_dispatch`.

### Changes
- Add a `workflow_dispatch` input `target_branch` (default: `release-1.4`).
- Add a `setup` job that resolves the branch and emits the scan matrix dynamically via `fromJSON`.
- The `cve-bump` job now consumes the resolved matrix instead of a hardcoded `[release-1.4]`.

### Behavior
- **Scheduled runs** (no input): unchanged — defaults to `release-1.4`.
- **Manual runs**: maintainers can dispatch the workflow against any branch by supplying `target_branch`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>