### PR TITLE
feat: add AWS ECR credential provider for Ratify v2

### DIFF
--- a/cmd/ratify-gatekeeper-provider/register.go
+++ b/cmd/ratify-gatekeeper-provider/register.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/notaryproject/ratify/v2/internal/store/registrystore"      // Register the registry store
 
 	// Register credential providers
+	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/aws"    // Register the AWS ECR credential provider factory
 	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/azure"  // Register the Azure credential provider factory
 	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/static" // Register the static credential provider factory
 

--- a/internal/store/credentialprovider/aws/register.go
+++ b/internal/store/credentialprovider/aws/register.go
@@ -1,0 +1,222 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/notaryproject/ratify-go"
+	"github.com/notaryproject/ratify/v2/internal/logger"
+	"github.com/notaryproject/ratify/v2/internal/store/credentialprovider"
+)
+
+var logOpt = logger.Option{ComponentType: logger.AuthProvider}
+
+const (
+	// providerName is the registered type name for the AWS ECR credential
+	// provider.
+	providerName = "aws"
+
+	// sessionName is the STS role session name used when assuming a role via
+	// IAM Roles for Service Accounts (IRSA).
+	sessionName = "ratifyEcrAuth"
+
+	// tokenRefreshBuffer is subtracted from the ECR token expiry so a cached
+	// credential is refreshed before it actually expires.
+	tokenRefreshBuffer = 5 * time.Minute
+)
+
+// authTokenGetter abstracts the ECR GetAuthorizationToken call so it can be
+// mocked in tests.
+type authTokenGetter interface {
+	GetAuthorizationToken(ctx context.Context, params *ecr.GetAuthorizationTokenInput, optFns ...func(*ecr.Options)) (*ecr.GetAuthorizationTokenOutput, error)
+}
+
+// IdentityProvider is an implementation of
+// [credentialprovider.CredentialSourceProvider] that retrieves credentials for
+// AWS Elastic Container Registry (ECR).
+//
+// Credentials are resolved from the default AWS credential chain, which on a
+// Kubernetes cluster is typically IAM Roles for Service Accounts (IRSA): the
+// AWS_REGION, AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE environment
+// variables injected into the pod.
+type IdentityProvider struct {
+	// region optionally overrides the AWS region. When empty, the region is
+	// derived from the ECR registry host of each request.
+	region string
+
+	// newClient builds an ECR client for the resolved region. It is a field so
+	// tests can substitute a mock.
+	newClient func(ctx context.Context, region string) (authTokenGetter, error)
+}
+
+// IdentityProviderOptions contains configuration options for the AWS ECR
+// identity provider.
+type IdentityProviderOptions struct {
+	// Region optionally pins the AWS region used to call ECR. When empty, the
+	// region is parsed from the registry host (e.g. the "us-east-1" in
+	// 123456789012.dkr.ecr.us-east-1.amazonaws.com).
+	Region string `json:"region,omitempty"`
+}
+
+func init() {
+	// Register the AWS ECR credential provider factory.
+	credentialprovider.RegisterCredentialProviderFactory(providerName, createAWSProvider)
+}
+
+// createAWSProvider creates a new AWS ECR identity provider from the given
+// credential provider options.
+func createAWSProvider(opts credentialprovider.Options) (ratify.RegistryCredentialGetter, error) {
+	raw, err := json.Marshal(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal configuration: %w", err)
+	}
+
+	var awsOpts IdentityProviderOptions
+	if err := json.Unmarshal(raw, &awsOpts); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal configuration: %w", err)
+	}
+
+	provider := &IdentityProvider{
+		region:    awsOpts.Region,
+		newClient: defaultECRClient,
+	}
+
+	return credentialprovider.NewCachedProvider(provider)
+}
+
+// defaultECRClient loads the default AWS configuration for the given region and
+// returns an ECR client. The default configuration resolves credentials from
+// the standard chain, including IRSA web identity tokens.
+func defaultECRClient(ctx context.Context, region string) (authTokenGetter, error) {
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+		config.WithWebIdentityRoleCredentialOptions(func(o *stscreds.WebIdentityRoleOptions) {
+			o.RoleSessionName = sessionName
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS configuration: %w", err)
+	}
+	return ecr.NewFromConfig(cfg), nil
+}
+
+// GetWithTTL implements [credentialprovider.CredentialSourceProvider]. It
+// retrieves an ECR authorization token for the registry identified by
+// serverAddress and returns it along with its remaining lifetime.
+func (p *IdentityProvider) GetWithTTL(ctx context.Context, serverAddress string) (credentialprovider.CredentialWithTTL, error) {
+	log := logger.GetLogger(ctx, logOpt)
+
+	region := p.region
+	if region == "" {
+		var err error
+		region, err = regionFromRegistry(serverAddress)
+		if err != nil {
+			return credentialprovider.CredentialWithTTL{}, err
+		}
+	}
+	log.Debugf("resolving ECR credential for %s (region=%s)", serverAddress, region)
+
+	client, err := p.newClient(ctx, region)
+	if err != nil {
+		return credentialprovider.CredentialWithTTL{}, err
+	}
+
+	output, err := client.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})
+	if err != nil {
+		return credentialprovider.CredentialWithTTL{}, fmt.Errorf("failed to get ECR authorization token for %s: %w", serverAddress, err)
+	}
+	if len(output.AuthorizationData) == 0 {
+		return credentialprovider.CredentialWithTTL{}, fmt.Errorf("ECR returned no authorization data for %s", serverAddress)
+	}
+
+	authData := output.AuthorizationData[0]
+	username, password, err := decodeAuthToken(aws.ToString(authData.AuthorizationToken))
+	if err != nil {
+		return credentialprovider.CredentialWithTTL{}, fmt.Errorf("failed to decode ECR authorization token for %s: %w", serverAddress, err)
+	}
+
+	ttl := resolveTokenTTL(log, serverAddress, authData.ExpiresAt)
+
+	return credentialprovider.CredentialWithTTL{
+		Credential: ratify.RegistryCredential{
+			Username: username,
+			Password: password,
+		},
+		TTL: ttl,
+	}, nil
+}
+
+// decodeAuthToken decodes the base64-encoded "username:password" ECR
+// authorization token.
+func decodeAuthToken(token string) (username, password string, err error) {
+	if token == "" {
+		return "", "", fmt.Errorf("empty authorization token")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return "", "", fmt.Errorf("could not base64-decode authorization token: %w", err)
+	}
+	parts := strings.SplitN(string(decoded), ":", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("authorization token is not in username:password format")
+	}
+	return parts[0], parts[1], nil
+}
+
+// ttlLogger is the subset of the logger used by resolveTokenTTL. It keeps the
+// helper testable without a full logger instance.
+type ttlLogger interface {
+	Warnf(format string, args ...interface{})
+}
+
+// resolveTokenTTL reports how long an ECR authorization token may be cached. An
+// ECR token is typically valid for 12 hours; a small buffer is subtracted so
+// the credential is refreshed before it expires. A missing or already-expired
+// expiry yields a zero TTL so the caching layer discards it.
+func resolveTokenTTL(log ttlLogger, serverAddress string, expiresAt *time.Time) time.Duration {
+	if expiresAt == nil {
+		log.Warnf("ECR did not return an expiry for %s; the credential will not be cached", serverAddress)
+		return 0
+	}
+	ttl := time.Until(*expiresAt) - tokenRefreshBuffer
+	if ttl < 0 {
+		log.Warnf("ECR returned an already-expired token for %s; it will not be cached", serverAddress)
+		return 0
+	}
+	return ttl
+}
+
+// regionFromRegistry parses the AWS region from an ECR registry host of the
+// form <account>.dkr.ecr.<region>.amazonaws.com(.cn).
+func regionFromRegistry(registry string) (string, error) {
+	parts := strings.Split(registry, ".")
+	if len(parts) >= 6 && parts[1] == "dkr" && parts[2] == "ecr" {
+		if region := parts[3]; region != "" {
+			return region, nil
+		}
+	}
+	return "", fmt.Errorf("could not determine AWS region from registry %q; set the provider's region option explicitly", registry)
+}

--- a/internal/store/credentialprovider/aws/register_test.go
+++ b/internal/store/credentialprovider/aws/register_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	"github.com/notaryproject/ratify/v2/internal/store/credentialprovider"
+)
+
+// fakeTTLLogger records warnings emitted by resolveTokenTTL.
+type fakeTTLLogger struct {
+	warned bool
+}
+
+func (l *fakeTTLLogger) Warnf(string, ...interface{}) { l.warned = true }
+
+// mockECRClient is a mock implementation of authTokenGetter.
+type mockECRClient struct {
+	output *ecr.GetAuthorizationTokenOutput
+	err    error
+}
+
+func (m *mockECRClient) GetAuthorizationToken(_ context.Context, _ *ecr.GetAuthorizationTokenInput, _ ...func(*ecr.Options)) (*ecr.GetAuthorizationTokenOutput, error) {
+	return m.output, m.err
+}
+
+func TestCreateAWSProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        credentialprovider.Options
+		expectError bool
+	}{
+		{
+			name: "valid with region",
+			opts: credentialprovider.Options{"provider": "aws", "region": "us-east-1"},
+		},
+		{
+			name: "valid without region",
+			opts: credentialprovider.Options{"provider": "aws"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := createAWSProvider(tt.opts)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatalf("expected a provider, got nil")
+			}
+		})
+	}
+}
+
+func TestRegionFromRegistry(t *testing.T) {
+	tests := []struct {
+		name        string
+		registry    string
+		want        string
+		expectError bool
+	}{
+		{name: "standard", registry: "123456789012.dkr.ecr.us-east-1.amazonaws.com", want: "us-east-1"},
+		{name: "china partition", registry: "123456789012.dkr.ecr.cn-north-1.amazonaws.com.cn", want: "cn-north-1"},
+		{name: "not ecr", registry: "myregistry.azurecr.io", expectError: true},
+		{name: "too short", registry: "foo.bar.com", expectError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := regionFromRegistry(tt.registry)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("region = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeAuthToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		token       string
+		wantUser    string
+		wantPass    string
+		expectError bool
+	}{
+		{
+			name:     "valid",
+			token:    base64.StdEncoding.EncodeToString([]byte("AWS:secret")),
+			wantUser: "AWS",
+			wantPass: "secret",
+		},
+		{
+			name:     "password with colon",
+			token:    base64.StdEncoding.EncodeToString([]byte("AWS:sec:ret")),
+			wantUser: "AWS",
+			wantPass: "sec:ret",
+		},
+		{name: "empty", token: "", expectError: true},
+		{name: "not base64", token: "%%%not-base64%%%", expectError: true},
+		{name: "no colon", token: base64.StdEncoding.EncodeToString([]byte("nocolon")), expectError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user, pass, err := decodeAuthToken(tt.token)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if user != tt.wantUser || pass != tt.wantPass {
+				t.Fatalf("got (%q,%q), want (%q,%q)", user, pass, tt.wantUser, tt.wantPass)
+			}
+		})
+	}
+}
+
+func TestResolveTokenTTL(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name       string
+		expiresAt  *time.Time
+		wantZero   bool
+		wantWarned bool
+	}{
+		{name: "nil expiry", expiresAt: nil, wantZero: true, wantWarned: true},
+		{name: "expired", expiresAt: ptrTime(now.Add(-time.Hour)), wantZero: true, wantWarned: true},
+		{name: "valid", expiresAt: ptrTime(now.Add(12 * time.Hour)), wantZero: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := &fakeTTLLogger{}
+			ttl := resolveTokenTTL(log, "registry", tt.expiresAt)
+			if tt.wantZero && ttl != 0 {
+				t.Fatalf("expected zero TTL, got %s", ttl)
+			}
+			if !tt.wantZero && ttl <= 0 {
+				t.Fatalf("expected positive TTL, got %s", ttl)
+			}
+			if log.warned != tt.wantWarned {
+				t.Fatalf("warned = %v, want %v", log.warned, tt.wantWarned)
+			}
+		})
+	}
+}
+
+func TestGetWithTTL(t *testing.T) {
+	validToken := base64.StdEncoding.EncodeToString([]byte("AWS:secret"))
+	expiry := time.Now().Add(12 * time.Hour)
+
+	tests := []struct {
+		name          string
+		region        string
+		serverAddress string
+		client        *mockECRClient
+		clientErr     error
+		expectError   bool
+		wantUser      string
+		wantPass      string
+	}{
+		{
+			name:          "success derives region",
+			serverAddress: "123456789012.dkr.ecr.us-west-2.amazonaws.com",
+			client: &mockECRClient{output: &ecr.GetAuthorizationTokenOutput{
+				AuthorizationData: []types.AuthorizationData{{
+					AuthorizationToken: aws.String(validToken),
+					ExpiresAt:          &expiry,
+				}},
+			}},
+			wantUser: "AWS",
+			wantPass: "secret",
+		},
+		{
+			name:          "success with explicit region",
+			region:        "eu-central-1",
+			serverAddress: "notaregistry",
+			client: &mockECRClient{output: &ecr.GetAuthorizationTokenOutput{
+				AuthorizationData: []types.AuthorizationData{{
+					AuthorizationToken: aws.String(validToken),
+					ExpiresAt:          &expiry,
+				}},
+			}},
+			wantUser: "AWS",
+			wantPass: "secret",
+		},
+		{
+			name:          "invalid registry without region",
+			serverAddress: "myregistry.azurecr.io",
+			client:        &mockECRClient{},
+			expectError:   true,
+		},
+		{
+			name:          "ecr error",
+			serverAddress: "123456789012.dkr.ecr.us-west-2.amazonaws.com",
+			client:        &mockECRClient{err: errors.New("boom")},
+			expectError:   true,
+		},
+		{
+			name:          "no auth data",
+			serverAddress: "123456789012.dkr.ecr.us-west-2.amazonaws.com",
+			client:        &mockECRClient{output: &ecr.GetAuthorizationTokenOutput{}},
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &IdentityProvider{
+				region: tt.region,
+				newClient: func(context.Context, string) (authTokenGetter, error) {
+					return tt.client, nil
+				},
+			}
+			got, err := p.GetWithTTL(context.Background(), tt.serverAddress)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Credential.Username != tt.wantUser || got.Credential.Password != tt.wantPass {
+				t.Fatalf("got (%q,%q), want (%q,%q)", got.Credential.Username, got.Credential.Password, tt.wantUser, tt.wantPass)
+			}
+			if got.TTL <= 0 {
+				t.Fatalf("expected positive TTL, got %s", got.TTL)
+			}
+		})
+	}
+}
+
+func TestGetWithTTLClientError(t *testing.T) {
+	p := &IdentityProvider{
+		region: "us-east-1",
+		newClient: func(context.Context, string) (authTokenGetter, error) {
+			return nil, errors.New("failed to build client")
+		},
+	}
+	if _, err := p.GetWithTTL(context.Background(), "123456789012.dkr.ecr.us-east-1.amazonaws.com"); err == nil {
+		t.Fatalf("expected error when client construction fails, got nil")
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }


### PR DESCRIPTION
## Description

Implements an **AWS ECR credential provider** for the Ratify v2 architecture, resolving GitHub issue #2354.

Ratify v2 refactored credential resolution around the `credentialprovider` factory + `CredentialSourceProvider.GetWithTTL` + `CachedProvider` pattern (see the existing Azure provider). This PR adds an AWS ECR provider following that same pattern.

### What it does
- Resolves credentials from the **default AWS credential chain** (IRSA: `AWS_ROLE_ARN` / `AWS_WEB_IDENTITY_TOKEN_FILE` on Kubernetes).
- Calls ECR `GetAuthorizationToken` and decodes the base64 `AWS:password` token into username/password.
- Derives the AWS **region from the ECR registry host** (`<acct>.dkr.ecr.<region>.amazonaws.com`); an explicit `region` option overrides it.
- Caches the credential per registry using the token's `ExpiresAt` (minus a 5-minute refresh buffer) as the TTL.
- Registered as credential provider type `aws` and wired into `cmd/ratify-gatekeeper-provider`.

### Testing
- Unit tests cover factory creation, region parsing, token decoding, TTL resolution, and the `GetWithTTL` success/error paths using a mocked ECR client.
- `go build ./...`, `go test` and `golangci-lint` all pass.

Resolves #2354
