### PR TITLE
feat: add Alibaba Cloud ACR credential provider for Ratify v2

### DIFF
--- a/cmd/ratify-gatekeeper-provider/register.go
+++ b/cmd/ratify-gatekeeper-provider/register.go
@@ -24,9 +24,10 @@ import (
 	_ "github.com/notaryproject/ratify/v2/internal/store/registrystore"      // Register the registry store
 
 	// Register credential providers
-	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/aws"    // Register the AWS ECR credential provider factory
-	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/azure"  // Register the Azure credential provider factory
-	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/static" // Register the static credential provider factory
+	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/alibabacloud" // Register the Alibaba Cloud ACR credential provider factory
+	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/aws"          // Register the AWS ECR credential provider factory
+	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/azure"        // Register the Azure credential provider factory
+	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/static"       // Register the static credential provider factory
 
 	// Register verifiers
 	_ "github.com/notaryproject/ratify/v2/internal/verifier/cosign"   // Register the Cosign verifier

--- a/internal/store/credentialprovider/alibabacloud/helper.go
+++ b/internal/store/credentialprovider/alibabacloud/helper.go
@@ -1,0 +1,59 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alibabacloud
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const acrNameSuffix = ".aliyuncs.com"
+
+// domainPattern extracts the optional ACR Enterprise Edition instance name and
+// the region from an Alibaba Cloud Registry host. The instance name is the
+// label preceding "-registry" (empty for a shared registry). Examples:
+//
+//	registry.cn-hangzhou.cr.aliyuncs.com                 (shared registry, no instance name)
+//	dahu-registry.cn-hangzhou.cr.aliyuncs.com            (EE instance "dahu")
+//	dahu-registry-vpc.cn-hangzhou.cr.aliyuncs.com        (EE instance "dahu", VPC endpoint)
+//
+// The pattern is kept identical to the Ratify v1 implementation to preserve the
+// same host-parsing behavior.
+var domainPattern = regexp.MustCompile(
+	`^(?:(?P<instanceName>[^.\s]+)-)?registry(?:-intl)?(?:-vpc)?(?:-internal)?(?:\.distributed)?\.(?P<region>[^.]+\-[^.]+)\.(?:cr\.)?aliyuncs\.com`)
+
+// acrMetaInfo holds the instance name and region parsed from an ACR host.
+type acrMetaInfo struct {
+	instanceName string
+	region       string
+}
+
+// parseACRHost parses the ACR Enterprise Edition instance name and region from
+// a registry host.
+func parseACRHost(host string) (*acrMetaInfo, error) {
+	if !strings.HasSuffix(host, acrNameSuffix) {
+		return nil, fmt.Errorf("invalid Alibaba Cloud Registry host %q which does not end with %q", host, acrNameSuffix)
+	}
+	subItems := domainPattern.FindStringSubmatch(host)
+	if len(subItems) != 3 || subItems[2] == "" {
+		return nil, fmt.Errorf("invalid Alibaba Cloud Registry host format %q", host)
+	}
+	return &acrMetaInfo{
+		instanceName: subItems[1],
+		region:       subItems[2],
+	}, nil
+}

--- a/internal/store/credentialprovider/alibabacloud/register.go
+++ b/internal/store/credentialprovider/alibabacloud/register.go
@@ -1,0 +1,272 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alibabacloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	cr20181201 "github.com/alibabacloud-go/cr-20181201/v2/client"
+	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
+	util "github.com/alibabacloud-go/tea-utils/v2/service"
+	"github.com/alibabacloud-go/tea/tea"
+	"github.com/aliyun/credentials-go/credentials"
+	"github.com/notaryproject/ratify-go"
+	"github.com/notaryproject/ratify/v2/internal/logger"
+	"github.com/notaryproject/ratify/v2/internal/store/credentialprovider"
+)
+
+var logOpt = logger.Option{ComponentType: logger.AuthProvider}
+
+const (
+	// providerName is the registered type name for the Alibaba Cloud ACR
+	// credential provider.
+	providerName = "alibabacloud"
+
+	// acrEndpointTemplate is the Alibaba Cloud Container Registry API endpoint
+	// template. See
+	// https://help.aliyun.com/zh/acr/developer-reference/api-cr-2018-12-01-endpoint
+	acrEndpointTemplate = "cr.%s.aliyuncs.com"
+
+	// envACRInstanceID is an optional environment fallback for the default ACR
+	// Enterprise Edition instance ID.
+	envACRInstanceID = "ALIBABA_CLOUD_ACR_INSTANCE_ID"
+
+	// tokenRefreshBuffer is subtracted from the ACR token expiry so a cached
+	// credential is refreshed before it actually expires.
+	tokenRefreshBuffer = 5 * time.Minute
+)
+
+// acrTokenGetter abstracts fetching an ACR authorization token so it can be
+// mocked in tests.
+type acrTokenGetter interface {
+	getACRToken(ctx context.Context, serverAddress, instanceID string) (*cr20181201.GetAuthorizationTokenResponseBody, error)
+}
+
+// acrClient is the subset of the Alibaba Cloud ACR client used by this package.
+// It is satisfied by *cr20181201.Client and allows mocking in tests.
+type acrClient interface {
+	GetAuthorizationTokenWithOptions(request *cr20181201.GetAuthorizationTokenRequest, runtime *util.RuntimeOptions) (*cr20181201.GetAuthorizationTokenResponse, error)
+}
+
+// IdentityProvider is an implementation of
+// [credentialprovider.CredentialSourceProvider] that retrieves credentials for
+// Alibaba Cloud Container Registry (ACR).
+//
+// Authentication uses RAM Roles for Service Accounts (RRSA): the
+// ALIBABA_CLOUD_ROLE_ARN, ALIBABA_CLOUD_OIDC_PROVIDER_ARN and
+// ALIBABA_CLOUD_OIDC_TOKEN_FILE environment variables injected into the pod are
+// consumed by the Alibaba Cloud credentials SDK to obtain STS credentials,
+// which are then exchanged for a short-lived ACR authorization token.
+type IdentityProvider struct {
+	// defaultInstanceID is the ACR Enterprise Edition instance ID used when a
+	// registry host does not map to a configured instance.
+	defaultInstanceID string
+
+	// instanceIDs maps an ACR EE instance name (parsed from the registry host)
+	// to its instance ID.
+	instanceIDs map[string]string
+
+	// tokenGetter fetches the ACR authorization token. It is a field so tests
+	// can substitute a mock.
+	tokenGetter acrTokenGetter
+}
+
+// instanceConfig maps an ACR Enterprise Edition instance name to its instance
+// ID.
+type instanceConfig struct {
+	// InstanceName is the ACR EE instance name, matching the label that
+	// precedes "-registry" in the registry host (e.g. "dahu" in
+	// dahu-registry.cn-hangzhou.cr.aliyuncs.com).
+	InstanceName string `json:"instanceName"`
+	// InstanceID is the ACR EE instance ID.
+	InstanceID string `json:"instanceId"`
+}
+
+// IdentityProviderOptions contains configuration options for the Alibaba Cloud
+// ACR identity provider.
+type IdentityProviderOptions struct {
+	// DefaultInstanceID is the ACR Enterprise Edition instance ID used when the
+	// registry host does not match a configured instance. When empty, the
+	// ALIBABA_CLOUD_ACR_INSTANCE_ID environment variable is used as a fallback.
+	DefaultInstanceID string `json:"defaultInstanceId,omitempty"`
+	// InstanceConfigs optionally maps ACR EE instance names to instance IDs for
+	// multi-instance clusters.
+	InstanceConfigs []instanceConfig `json:"acrInstancesConfig,omitempty"`
+}
+
+func init() {
+	// Register the Alibaba Cloud ACR credential provider factory.
+	credentialprovider.RegisterCredentialProviderFactory(providerName, createAlibabaCloudProvider)
+}
+
+// createAlibabaCloudProvider creates a new Alibaba Cloud ACR identity provider
+// from the given credential provider options.
+func createAlibabaCloudProvider(opts credentialprovider.Options) (ratify.RegistryCredentialGetter, error) {
+	raw, err := json.Marshal(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal configuration: %w", err)
+	}
+
+	var acrOpts IdentityProviderOptions
+	if err := json.Unmarshal(raw, &acrOpts); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal configuration: %w", err)
+	}
+
+	instanceIDs := make(map[string]string, len(acrOpts.InstanceConfigs))
+	for _, ic := range acrOpts.InstanceConfigs {
+		instanceIDs[ic.InstanceName] = ic.InstanceID
+	}
+
+	defaultInstanceID := acrOpts.DefaultInstanceID
+	if defaultInstanceID == "" {
+		defaultInstanceID = os.Getenv(envACRInstanceID)
+	}
+	if defaultInstanceID == "" && len(instanceIDs) == 0 {
+		return nil, fmt.Errorf("no ACR instance ID provided: set defaultInstanceId, acrInstancesConfig, or the %s environment variable", envACRInstanceID)
+	}
+
+	provider := &IdentityProvider{
+		defaultInstanceID: defaultInstanceID,
+		instanceIDs:       instanceIDs,
+		tokenGetter:       &defaultACRTokenGetter{newClient: defaultACRClient},
+	}
+
+	return credentialprovider.NewCachedProvider(provider)
+}
+
+// GetWithTTL implements [credentialprovider.CredentialSourceProvider]. It
+// retrieves an ACR authorization token for the registry identified by
+// serverAddress and returns it along with its remaining lifetime.
+func (p *IdentityProvider) GetWithTTL(ctx context.Context, serverAddress string) (credentialprovider.CredentialWithTTL, error) {
+	log := logger.GetLogger(ctx, logOpt)
+
+	meta, err := parseACRHost(serverAddress)
+	if err != nil {
+		return credentialprovider.CredentialWithTTL{}, err
+	}
+
+	instanceID := p.defaultInstanceID
+	if id, ok := p.instanceIDs[meta.instanceName]; ok {
+		instanceID = id
+	}
+	if instanceID == "" {
+		return credentialprovider.CredentialWithTTL{}, fmt.Errorf("no ACR instance ID configured for registry %q", serverAddress)
+	}
+	log.Debugf("resolving ACR credential for %s (region=%s, instance=%s)", serverAddress, meta.region, instanceID)
+
+	body, err := p.tokenGetter.getACRToken(ctx, serverAddress, instanceID)
+	if err != nil {
+		return credentialprovider.CredentialWithTTL{}, fmt.Errorf("failed to get ACR authorization token for %s: %w", serverAddress, err)
+	}
+	if body == nil {
+		return credentialprovider.CredentialWithTTL{}, fmt.Errorf("received nil ACR authorization token for %s", serverAddress)
+	}
+
+	ttl := resolveTokenTTL(log, serverAddress, tea.Int64Value(body.ExpireTime))
+
+	return credentialprovider.CredentialWithTTL{
+		Credential: ratify.RegistryCredential{
+			Username: tea.StringValue(body.TempUsername),
+			Password: tea.StringValue(body.AuthorizationToken),
+		},
+		TTL: ttl,
+	}, nil
+}
+
+// defaultACRTokenGetter is the production implementation of acrTokenGetter that
+// talks to the Alibaba Cloud ACR API using RRSA credentials.
+type defaultACRTokenGetter struct {
+	// newClient builds an ACR client for the resolved region. It is a field so
+	// tests can substitute a mock.
+	newClient func(region string) (acrClient, error)
+}
+
+// getACRToken exchanges the pod's RRSA credentials for a short-lived ACR
+// authorization token for the given instance.
+func (g *defaultACRTokenGetter) getACRToken(_ context.Context, serverAddress, instanceID string) (*cr20181201.GetAuthorizationTokenResponseBody, error) {
+	meta, err := parseACRHost(serverAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := g.newClient(meta.region)
+	if err != nil {
+		return nil, err
+	}
+
+	request := &cr20181201.GetAuthorizationTokenRequest{
+		InstanceId: tea.String(instanceID),
+	}
+	response, err := client.GetAuthorizationTokenWithOptions(request, &util.RuntimeOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if response == nil || response.Body == nil {
+		return nil, fmt.Errorf("received empty ACR authorization token response")
+	}
+	return response.Body, nil
+}
+
+// defaultACRClient builds an Alibaba Cloud ACR client for the given region using
+// RRSA credentials resolved from the environment.
+func defaultACRClient(region string) (acrClient, error) {
+	// credentials.NewCredential(nil) resolves RRSA credentials from the
+	// ALIBABA_CLOUD_ROLE_ARN, ALIBABA_CLOUD_OIDC_PROVIDER_ARN and
+	// ALIBABA_CLOUD_OIDC_TOKEN_FILE environment variables.
+	cred, err := credentials.NewCredential(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init Alibaba Cloud SDK credential: %w", err)
+	}
+
+	config := &openapi.Config{
+		Credential: cred,
+		Endpoint:   tea.String(fmt.Sprintf(acrEndpointTemplate, region)),
+		RegionId:   tea.String(region),
+	}
+	client, err := cr20181201.NewClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init Alibaba Cloud ACR client: %w", err)
+	}
+	return client, nil
+}
+
+// ttlLogger is the subset of the logger used by resolveTokenTTL. It keeps the
+// helper testable without a full logger instance.
+type ttlLogger interface {
+	Warnf(format string, args ...interface{})
+}
+
+// resolveTokenTTL reports how long an ACR authorization token may be cached. An
+// ACR token is typically valid for one hour; a small refresh buffer is
+// subtracted so the credential is refreshed before it expires. A missing expiry,
+// or one that falls within the refresh buffer, yields a zero TTL so the caching
+// layer does not store a credential that is expired or about to expire.
+func resolveTokenTTL(log ttlLogger, serverAddress string, expireTimeMillis int64) time.Duration {
+	if expireTimeMillis <= 0 {
+		log.Warnf("ACR did not return an expiry for %s; the credential will not be cached", serverAddress)
+		return 0
+	}
+	ttl := time.Until(time.UnixMilli(expireTimeMillis)) - tokenRefreshBuffer
+	if ttl < 0 {
+		log.Warnf("ACR token for %s expires within the refresh buffer; it will not be cached", serverAddress)
+		return 0
+	}
+	return ttl
+}

--- a/internal/store/credentialprovider/alibabacloud/register_test.go
+++ b/internal/store/credentialprovider/alibabacloud/register_test.go
@@ -1,0 +1,380 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alibabacloud
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	cr20181201 "github.com/alibabacloud-go/cr-20181201/v2/client"
+	util "github.com/alibabacloud-go/tea-utils/v2/service"
+	"github.com/alibabacloud-go/tea/tea"
+	"github.com/notaryproject/ratify/v2/internal/store/credentialprovider"
+)
+
+// fakeTTLLogger records warnings emitted by resolveTokenTTL.
+type fakeTTLLogger struct {
+	warned bool
+}
+
+func (l *fakeTTLLogger) Warnf(string, ...interface{}) { l.warned = true }
+
+// mockACRTokenGetter is a mock implementation of acrTokenGetter.
+type mockACRTokenGetter struct {
+	body          *cr20181201.GetAuthorizationTokenResponseBody
+	err           error
+	gotInstanceID string
+	gotServerAddr string
+}
+
+func (m *mockACRTokenGetter) getACRToken(_ context.Context, serverAddress, instanceID string) (*cr20181201.GetAuthorizationTokenResponseBody, error) {
+	m.gotInstanceID = instanceID
+	m.gotServerAddr = serverAddress
+	return m.body, m.err
+}
+
+// mockACRClient is a mock implementation of acrClient.
+type mockACRClient struct {
+	response *cr20181201.GetAuthorizationTokenResponse
+	err      error
+	gotID    string
+}
+
+func (m *mockACRClient) GetAuthorizationTokenWithOptions(request *cr20181201.GetAuthorizationTokenRequest, _ *util.RuntimeOptions) (*cr20181201.GetAuthorizationTokenResponse, error) {
+	if request != nil {
+		m.gotID = tea.StringValue(request.InstanceId)
+	}
+	return m.response, m.err
+}
+
+func TestDefaultACRTokenGetter(t *testing.T) {
+	validResponse := &cr20181201.GetAuthorizationTokenResponse{
+		Body: &cr20181201.GetAuthorizationTokenResponseBody{
+			TempUsername:       tea.String("temp-user"),
+			AuthorizationToken: tea.String("temp-token"),
+		},
+	}
+
+	tests := []struct {
+		name          string
+		serverAddress string
+		client        acrClient
+		clientErr     error
+		expectError   bool
+		wantID        string
+	}{
+		{
+			name:          "success",
+			serverAddress: "my-registry.cn-hangzhou.cr.aliyuncs.com",
+			client:        &mockACRClient{response: validResponse},
+			wantID:        "cri-123",
+		},
+		{
+			name:          "invalid host",
+			serverAddress: "myregistry.azurecr.io",
+			client:        &mockACRClient{response: validResponse},
+			expectError:   true,
+		},
+		{
+			name:          "client construction error",
+			serverAddress: "my-registry.cn-hangzhou.cr.aliyuncs.com",
+			clientErr:     errors.New("no credentials"),
+			expectError:   true,
+		},
+		{
+			name:          "api error",
+			serverAddress: "my-registry.cn-hangzhou.cr.aliyuncs.com",
+			client:        &mockACRClient{err: errors.New("boom")},
+			expectError:   true,
+		},
+		{
+			name:          "nil body",
+			serverAddress: "my-registry.cn-hangzhou.cr.aliyuncs.com",
+			client:        &mockACRClient{response: &cr20181201.GetAuthorizationTokenResponse{}},
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getter := &defaultACRTokenGetter{
+				newClient: func(string) (acrClient, error) {
+					if tt.clientErr != nil {
+						return nil, tt.clientErr
+					}
+					return tt.client, nil
+				},
+			}
+			body, err := getter.getACRToken(context.Background(), tt.serverAddress, "cri-123")
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if body == nil {
+				t.Fatalf("expected a body, got nil")
+			}
+			if mc, ok := tt.client.(*mockACRClient); ok && mc.gotID != tt.wantID {
+				t.Fatalf("instance id = %q, want %q", mc.gotID, tt.wantID)
+			}
+		})
+	}
+}
+
+// TestDefaultACRClient exercises the production client factory. Credential
+// resolution is lazy, so construction succeeds and returns a usable client.
+func TestDefaultACRClient(t *testing.T) {
+	client, err := defaultACRClient("cn-hangzhou")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatalf("expected a client, got nil")
+	}
+}
+
+func TestParseACRHost(t *testing.T) {
+	tests := []struct {
+		name         string
+		host         string
+		wantInstance string
+		wantRegion   string
+		expectError  bool
+	}{
+		{name: "shared instance", host: "registry.cn-hangzhou.cr.aliyuncs.com", wantInstance: "", wantRegion: "cn-hangzhou"},
+		{name: "ee instance", host: "my-registry.cn-hangzhou.cr.aliyuncs.com", wantInstance: "my", wantRegion: "cn-hangzhou"},
+		{name: "vpc endpoint", host: "test-registry-vpc.cn-hangzhou.cr.aliyuncs.com", wantInstance: "test", wantRegion: "cn-hangzhou"},
+		{name: "v1 parity dahu vpc", host: "dahu-registry-vpc.cn-hangzhou.cr.aliyuncs.com", wantInstance: "dahu", wantRegion: "cn-hangzhou"},
+		{name: "no cr label", host: "registry-vpc.cn-beijing.aliyuncs.com", wantInstance: "", wantRegion: "cn-beijing"},
+		{name: "wrong suffix", host: "myregistry.azurecr.io", expectError: true},
+		{name: "malformed", host: "foo.aliyuncs.com", expectError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta, err := parseACRHost(tt.host)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if meta.instanceName != tt.wantInstance || meta.region != tt.wantRegion {
+				t.Fatalf("got (%q,%q), want (%q,%q)", meta.instanceName, meta.region, tt.wantInstance, tt.wantRegion)
+			}
+		})
+	}
+}
+
+func TestCreateAlibabaCloudProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        credentialprovider.Options
+		env         string
+		expectError bool
+	}{
+		{
+			name: "default instance id",
+			opts: credentialprovider.Options{"provider": "alibabacloud", "defaultInstanceId": "cri-123"},
+		},
+		{
+			name: "instance config only",
+			opts: credentialprovider.Options{
+				"provider": "alibabacloud",
+				"acrInstancesConfig": []map[string]string{
+					{"instanceName": "my", "instanceId": "cri-abc"},
+				},
+			},
+		},
+		{
+			name:        "no instance configured",
+			opts:        credentialprovider.Options{"provider": "alibabacloud"},
+			expectError: true,
+		},
+		{
+			name: "env fallback",
+			opts: credentialprovider.Options{"provider": "alibabacloud"},
+			env:  "cri-env",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env != "" {
+				t.Setenv(envACRInstanceID, tt.env)
+			}
+			got, err := createAlibabaCloudProvider(tt.opts)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatalf("expected a provider, got nil")
+			}
+		})
+	}
+}
+
+func TestResolveTokenTTL(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name       string
+		expireMs   int64
+		wantZero   bool
+		wantWarned bool
+	}{
+		{name: "zero", expireMs: 0, wantZero: true, wantWarned: true},
+		{name: "expired", expireMs: now.Add(-time.Hour).UnixMilli(), wantZero: true, wantWarned: true},
+		{name: "valid", expireMs: now.Add(time.Hour).UnixMilli(), wantZero: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := &fakeTTLLogger{}
+			ttl := resolveTokenTTL(log, "registry", tt.expireMs)
+			if tt.wantZero && ttl != 0 {
+				t.Fatalf("expected zero TTL, got %s", ttl)
+			}
+			if !tt.wantZero && ttl <= 0 {
+				t.Fatalf("expected positive TTL, got %s", ttl)
+			}
+			if log.warned != tt.wantWarned {
+				t.Fatalf("warned = %v, want %v", log.warned, tt.wantWarned)
+			}
+		})
+	}
+}
+
+func TestGetWithTTL(t *testing.T) {
+	expiry := time.Now().Add(time.Hour).UnixMilli()
+	validBody := &cr20181201.GetAuthorizationTokenResponseBody{
+		TempUsername:       tea.String("temp-user"),
+		AuthorizationToken: tea.String("temp-token"),
+		ExpireTime:         tea.Int64(expiry),
+	}
+
+	tests := []struct {
+		name           string
+		provider       *IdentityProvider
+		serverAddress  string
+		getter         *mockACRTokenGetter
+		expectError    bool
+		wantInstanceID string
+		wantUser       string
+		wantPass       string
+	}{
+		{
+			name: "default instance",
+			provider: &IdentityProvider{
+				defaultInstanceID: "cri-default",
+				instanceIDs:       map[string]string{},
+			},
+			serverAddress:  "registry.cn-hangzhou.cr.aliyuncs.com",
+			getter:         &mockACRTokenGetter{body: validBody},
+			wantInstanceID: "cri-default",
+			wantUser:       "temp-user",
+			wantPass:       "temp-token",
+		},
+		{
+			name: "instance name mapping",
+			provider: &IdentityProvider{
+				defaultInstanceID: "cri-default",
+				instanceIDs:       map[string]string{"my": "cri-my"},
+			},
+			serverAddress:  "my-registry.cn-hangzhou.cr.aliyuncs.com",
+			getter:         &mockACRTokenGetter{body: validBody},
+			wantInstanceID: "cri-my",
+			wantUser:       "temp-user",
+			wantPass:       "temp-token",
+		},
+		{
+			name: "invalid host",
+			provider: &IdentityProvider{
+				defaultInstanceID: "cri-default",
+				instanceIDs:       map[string]string{},
+			},
+			serverAddress: "myregistry.azurecr.io",
+			getter:        &mockACRTokenGetter{body: validBody},
+			expectError:   true,
+		},
+		{
+			name: "no instance id resolved",
+			provider: &IdentityProvider{
+				defaultInstanceID: "",
+				instanceIDs:       map[string]string{"other": "cri-other"},
+			},
+			serverAddress: "registry.cn-hangzhou.cr.aliyuncs.com",
+			getter:        &mockACRTokenGetter{body: validBody},
+			expectError:   true,
+		},
+		{
+			name: "token getter error",
+			provider: &IdentityProvider{
+				defaultInstanceID: "cri-default",
+				instanceIDs:       map[string]string{},
+			},
+			serverAddress: "registry.cn-hangzhou.cr.aliyuncs.com",
+			getter:        &mockACRTokenGetter{err: errors.New("boom")},
+			expectError:   true,
+		},
+		{
+			name: "nil body",
+			provider: &IdentityProvider{
+				defaultInstanceID: "cri-default",
+				instanceIDs:       map[string]string{},
+			},
+			serverAddress: "registry.cn-hangzhou.cr.aliyuncs.com",
+			getter:        &mockACRTokenGetter{body: nil},
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.provider.tokenGetter = tt.getter
+			got, err := tt.provider.GetWithTTL(context.Background(), tt.serverAddress)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.getter.gotInstanceID != tt.wantInstanceID {
+				t.Fatalf("instance id = %q, want %q", tt.getter.gotInstanceID, tt.wantInstanceID)
+			}
+			if got.Credential.Username != tt.wantUser || got.Credential.Password != tt.wantPass {
+				t.Fatalf("got (%q,%q), want (%q,%q)", got.Credential.Username, got.Credential.Password, tt.wantUser, tt.wantPass)
+			}
+			if got.TTL <= 0 {
+				t.Fatalf("expected positive TTL, got %s", got.TTL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Implements an **Alibaba Cloud ACR credential provider** for the Ratify v2 architecture, resolving GitHub issue #2351.

Ratify v2 refactored credential resolution around the `credentialprovider` factory + `CredentialSourceProvider.GetWithTTL` + `CachedProvider` pattern (see the existing Azure provider). This PR adds an Alibaba Cloud ACR provider following that same pattern.

### What it does
- Authenticates via **RAM Roles for Service Accounts (RRSA)** — `ALIBABA_CLOUD_ROLE_ARN` / `ALIBABA_CLOUD_OIDC_PROVIDER_ARN` / `ALIBABA_CLOUD_OIDC_TOKEN_FILE` consumed by the Alibaba Cloud credentials SDK.
- Exchanges the STS credentials for a short-lived ACR authorization token via `GetAuthorizationToken` and returns the temp username/token.
- Parses the **region and ACR EE instance name** from the registry host; supports a `defaultInstanceId`, per-instance `acrInstancesConfig` mapping, and an `ALIBABA_CLOUD_ACR_INSTANCE_ID` env fallback.
- Caches the credential per registry using the token's `ExpireTime` (minus a 5-minute refresh buffer) as the TTL.
- Registered as credential provider type `alibabacloud` and wired into `cmd/ratify-gatekeeper-provider`.

### Testing
- Unit tests cover factory creation (incl. env fallback), ACR host parsing, TTL resolution, and the `GetWithTTL` success/error paths using a mocked token getter.
- `go build ./...`, `go test` and `golangci-lint` all pass.

Resolves #2351
