### PR TITLE
feat: add ratify CLI entrypoint built on ratify-go

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,7 @@ builds:
       - -X github.com/notaryproject/ratify/v2/internal/version.Version={{ .Version }}
       - -X github.com/notaryproject/ratify/v2/internal/version.GitTag={{ .Tag }}
       - -X github.com/notaryproject/ratify/v2/internal/version.GitCommitHash={{ .FullCommit }}
+      - -X github.com/notaryproject/ratify/v2/internal/version.GitTreeState=unmodified
 
 release:
   prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,26 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
+  - id: ratify
+    dir: cmd/ratify
+    binary: ratify
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X github.com/notaryproject/ratify/v2/internal/version.Version={{ .Version }}
+      - -X github.com/notaryproject/ratify/v2/internal/version.GitTag={{ .Tag }}
+      - -X github.com/notaryproject/ratify/v2/internal/version.GitCommitHash={{ .FullCommit }}
 
 release:
   prerelease: auto

--- a/cmd/ratify/main.go
+++ b/cmd/ratify/main.go
@@ -1,0 +1,31 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/notaryproject/ratify/v2/pkg/common"
+	"github.com/sirupsen/logrus"
+)
+
+// main is the entry point for the Ratify CLI.
+func main() {
+	common.SetLoggingLevelFromEnv(logrus.StandardLogger())
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/ratify/register.go
+++ b/cmd/ratify/register.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	// Register policy enforcers
+	_ "github.com/notaryproject/ratify/v2/internal/policyenforcer/threshold" // Register threshold policy enforcer
+
+	// Register stores
+	_ "github.com/notaryproject/ratify/v2/internal/store/filesystemocistore" // Register the filesystem OCI store
+	_ "github.com/notaryproject/ratify/v2/internal/store/registrystore"      // Register the registry store
+
+	// Register credential providers
+	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/alibabacloud" // Register the Alibaba Cloud ACR credential provider factory
+	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/aws"          // Register the AWS ECR credential provider factory
+	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/azure"        // Register the Azure credential provider factory
+	_ "github.com/notaryproject/ratify/v2/internal/store/credentialprovider/static"       // Register the static credential provider factory
+
+	// Register verifiers
+	_ "github.com/notaryproject/ratify/v2/internal/verifier/cosign"   // Register the Cosign verifier
+	_ "github.com/notaryproject/ratify/v2/internal/verifier/notation" // Register the Notation verifier
+
+	// Register key providers
+	_ "github.com/notaryproject/ratify/v2/internal/verifier/keyprovider/azurekeyvault"      // Register the Azure Key Vault key provider
+	_ "github.com/notaryproject/ratify/v2/internal/verifier/keyprovider/filesystemprovider" // Register the filesystem key provider
+	_ "github.com/notaryproject/ratify/v2/internal/verifier/keyprovider/inlineprovider"     // Register the inline key provider
+)

--- a/cmd/ratify/report.go
+++ b/cmd/ratify/report.go
@@ -1,0 +1,146 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/notaryproject/ratify-go"
+)
+
+// renderedResult is a serializable view of [ratify.ValidationResult].
+type renderedResult struct {
+	Subject         string            `json:"subject"`
+	Succeeded       bool              `json:"succeeded"`
+	ArtifactReports []*renderedReport `json:"artifactReports,omitempty"`
+}
+
+// renderedReport is a serializable view of [ratify.ValidationReport].
+type renderedReport struct {
+	Subject         string                  `json:"subject"`
+	Artifact        string                  `json:"artifact"`
+	Results         []*renderedVerification `json:"results,omitempty"`
+	ArtifactReports []*renderedReport       `json:"artifactReports,omitempty"`
+}
+
+// renderedVerification is a serializable view of [ratify.VerificationResult].
+type renderedVerification struct {
+	Verifier    string `json:"verifier"`
+	Description string `json:"description,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// newRenderedResult converts a [ratify.ValidationResult] into a serializable
+// view that is safe to marshal to JSON and render as text.
+func newRenderedResult(subject string, src *ratify.ValidationResult) *renderedResult {
+	out := &renderedResult{Subject: subject}
+	if src == nil {
+		return out
+	}
+	out.Succeeded = src.Succeeded
+	out.ArtifactReports = newRenderedReports(src.ArtifactReports)
+	return out
+}
+
+func newRenderedReports(src []*ratify.ValidationReport) []*renderedReport {
+	if len(src) == 0 {
+		return nil
+	}
+	reports := make([]*renderedReport, 0, len(src))
+	for _, report := range src {
+		if report == nil {
+			continue
+		}
+		rendered := &renderedReport{
+			Subject:         report.Subject,
+			Artifact:        report.Artifact.Digest.String(),
+			ArtifactReports: newRenderedReports(report.ArtifactReports),
+		}
+		for _, result := range report.Results {
+			if result == nil {
+				continue
+			}
+			rendered.Results = append(rendered.Results, newRenderedVerification(result))
+		}
+		reports = append(reports, rendered)
+	}
+	return reports
+}
+
+func newRenderedVerification(src *ratify.VerificationResult) *renderedVerification {
+	rendered := &renderedVerification{Description: src.Description}
+	if src.Verifier != nil {
+		rendered.Verifier = src.Verifier.Name()
+	}
+	if src.Err != nil {
+		rendered.Error = src.Err.Error()
+	}
+	return rendered
+}
+
+// printResult writes the verification result to w in the requested format.
+func printResult(w io.Writer, subject, format string, src *ratify.ValidationResult) error {
+	rendered := newRenderedResult(subject, src)
+	if format == outputJSON {
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(rendered)
+	}
+	return printResultText(w, rendered)
+}
+
+func printResultText(w io.Writer, rendered *renderedResult) error {
+	status := "FAILED"
+	if rendered.Succeeded {
+		status = "SUCCEEDED"
+	}
+	if _, err := fmt.Fprintf(w, "Subject:   %s\nSucceeded: %t (%s)\n", rendered.Subject, rendered.Succeeded, status); err != nil {
+		return err
+	}
+	if len(rendered.ArtifactReports) == 0 {
+		_, err := fmt.Fprintln(w, "No artifact reports were produced.")
+		return err
+	}
+	return printReportsText(w, rendered.ArtifactReports, 1)
+}
+
+func printReportsText(w io.Writer, reports []*renderedReport, depth int) error {
+	indent := strings.Repeat("  ", depth)
+	for _, report := range reports {
+		if _, err := fmt.Fprintf(w, "%s- artifact: %s\n", indent, report.Artifact); err != nil {
+			return err
+		}
+		for _, result := range report.Results {
+			line := fmt.Sprintf("%s    verifier=%s", indent, result.Verifier)
+			if result.Description != "" {
+				line += fmt.Sprintf(" description=%q", result.Description)
+			}
+			if result.Error != "" {
+				line += fmt.Sprintf(" error=%q", result.Error)
+			}
+			if _, err := fmt.Fprintln(w, line); err != nil {
+				return err
+			}
+		}
+		if err := printReportsText(w, report.ArtifactReports, depth+1); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/ratify/report_test.go
+++ b/cmd/ratify/report_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/notaryproject/ratify-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// stubVerifier is a minimal [ratify.Verifier] implementation used to populate
+// verification results in tests.
+type stubVerifier struct {
+	name string
+}
+
+func (s *stubVerifier) Name() string                       { return s.name }
+func (s *stubVerifier) Type() string                       { return "stub" }
+func (s *stubVerifier) Verifiable(ocispec.Descriptor) bool { return true }
+func (s *stubVerifier) Verify(context.Context, *ratify.VerifyOptions) (*ratify.VerificationResult, error) {
+	return nil, nil
+}
+
+func sampleResult() *ratify.ValidationResult {
+	return &ratify.ValidationResult{
+		Succeeded: true,
+		ArtifactReports: []*ratify.ValidationReport{
+			{
+				Subject: "registry.example/repo:v1",
+				Artifact: ocispec.Descriptor{
+					Digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+				},
+				Results: []*ratify.VerificationResult{
+					{
+						Verifier:    &stubVerifier{name: "notation"},
+						Description: "signature verified",
+					},
+					{
+						Verifier: &stubVerifier{name: "cosign"},
+						Err:      errors.New("signature not found"),
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestNewRenderedResult(t *testing.T) {
+	rendered := newRenderedResult("registry.example/repo:v1", sampleResult())
+	if !rendered.Succeeded {
+		t.Error("expected rendered result to be succeeded")
+	}
+	if rendered.Subject != "registry.example/repo:v1" {
+		t.Errorf("unexpected subject: %q", rendered.Subject)
+	}
+	if len(rendered.ArtifactReports) != 1 {
+		t.Fatalf("expected 1 artifact report, got %d", len(rendered.ArtifactReports))
+	}
+	report := rendered.ArtifactReports[0]
+	if len(report.Results) != 2 {
+		t.Fatalf("expected 2 verification results, got %d", len(report.Results))
+	}
+	if report.Results[0].Verifier != "notation" || report.Results[0].Description != "signature verified" {
+		t.Errorf("unexpected first result: %+v", report.Results[0])
+	}
+	if report.Results[1].Verifier != "cosign" || report.Results[1].Error != "signature not found" {
+		t.Errorf("unexpected second result: %+v", report.Results[1])
+	}
+}
+
+func TestNewRenderedResult_Nil(t *testing.T) {
+	rendered := newRenderedResult("registry.example/repo:v1", nil)
+	if rendered.Succeeded {
+		t.Error("expected nil result to render as not succeeded")
+	}
+	if rendered.Subject != "registry.example/repo:v1" {
+		t.Errorf("unexpected subject: %q", rendered.Subject)
+	}
+	if rendered.ArtifactReports != nil {
+		t.Errorf("expected no artifact reports, got %v", rendered.ArtifactReports)
+	}
+}
+
+func TestPrintResult_Text(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printResult(&buf, "registry.example/repo:v1", outputText, sampleResult()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"SUCCEEDED", "verifier=notation", "verifier=cosign", "signature not found"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintResult_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printResult(&buf, "registry.example/repo:v1", outputJSON, sampleResult()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var decoded renderedResult
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("failed to decode JSON output: %v", err)
+	}
+	if !decoded.Succeeded {
+		t.Error("expected decoded result to be succeeded")
+	}
+	if len(decoded.ArtifactReports) != 1 || len(decoded.ArtifactReports[0].Results) != 2 {
+		t.Errorf("unexpected decoded structure: %+v", decoded)
+	}
+}
+
+func TestPrintResult_TextNoReports(t *testing.T) {
+	var buf bytes.Buffer
+	result := &ratify.ValidationResult{Succeeded: false}
+	if err := printResult(&buf, "registry.example/repo:v1", outputText, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "FAILED") {
+		t.Errorf("expected FAILED status; got:\n%s", out)
+	}
+	if !strings.Contains(out, "No artifact reports") {
+		t.Errorf("expected no-reports notice; got:\n%s", out)
+	}
+}

--- a/cmd/ratify/root.go
+++ b/cmd/ratify/root.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// newRootCmd creates the root `ratify` command and wires up its subcommands.
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ratify",
+		Short: "Ratify is a verification engine for supply chain artifacts",
+		Long: `Ratify verifies supply chain artifacts (such as signatures and
+attestations) against a configurable set of verifiers, stores, and policies.
+
+The CLI is built on top of the ratify-go library and shares the same
+configuration format as the Ratify Gatekeeper provider.`,
+		// Usage is only helpful for flag/argument errors; keep runtime errors
+		// (e.g. a failed verification) from printing the full usage text.
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(newVerifyCmd())
+	cmd.AddCommand(newVersionCmd())
+	return cmd
+}

--- a/cmd/ratify/root_test.go
+++ b/cmd/ratify/root_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewRootCmd(t *testing.T) {
+	cmd := newRootCmd()
+	if cmd.Use != "ratify" {
+		t.Errorf("unexpected root command use: got %q, want %q", cmd.Use, "ratify")
+	}
+	if !cmd.SilenceUsage {
+		t.Error("expected SilenceUsage to be true on the root command")
+	}
+
+	wantSubcommands := map[string]bool{"verify": false, "version": false}
+	for _, sub := range cmd.Commands() {
+		name := strings.Fields(sub.Use)[0]
+		if _, ok := wantSubcommands[name]; ok {
+			wantSubcommands[name] = true
+		}
+	}
+	for name, found := range wantSubcommands {
+		if !found {
+			t.Errorf("expected root command to register subcommand %q", name)
+		}
+	}
+}

--- a/cmd/ratify/verify.go
+++ b/cmd/ratify/verify.go
@@ -67,7 +67,9 @@ the policy or if an error occurs during verification.`,
 	flags.StringVarP(&opts.subject, "subject", "s", "", "subject artifact reference to verify (required)")
 	flags.StringVarP(&opts.configPath, "config", "c", "", "path to the ratify configuration file (default \"$HOME/.ratify/config.json\")")
 	flags.StringVarP(&opts.output, "output", "o", outputText, "output format, one of: text, json")
-	_ = cmd.MarkFlagRequired("subject")
+	if err := cmd.MarkFlagRequired("subject"); err != nil {
+		panic(fmt.Sprintf("failed to mark %q flag as required: %v", "subject", err))
+	}
 	return cmd
 }
 

--- a/cmd/ratify/verify.go
+++ b/cmd/ratify/verify.go
@@ -1,0 +1,139 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/notaryproject/ratify/v2/internal/executor"
+	"github.com/spf13/cobra"
+)
+
+const (
+	outputText = "text"
+	outputJSON = "json"
+
+	configFileName = "config.json"
+	configFileDir  = ".ratify"
+)
+
+// verifyOptions holds the parsed flags for the `ratify verify` command.
+type verifyOptions struct {
+	subject    string
+	configPath string
+	output     string
+}
+
+// newVerifyCmd creates the `ratify verify` command.
+func newVerifyCmd() *cobra.Command {
+	opts := &verifyOptions{}
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verify an artifact against the configured verifiers and policy",
+		Long: `Verify resolves the given subject artifact, verifies all associated
+artifacts (such as signatures and attestations) using the configured verifiers,
+and evaluates the results against the configured policy.
+
+The command exits with a non-zero status code if the artifact does not satisfy
+the policy or if an error occurs during verification.`,
+		Example: `  # Verify an artifact using the default configuration file
+  ratify verify --subject myregistry.io/repo@sha256:abc123
+
+  # Verify an artifact using a custom configuration file and JSON output
+  ratify verify --subject myregistry.io/repo:v1 --config ./config.json --output json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runVerify(cmd, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.subject, "subject", "s", "", "subject artifact reference to verify (required)")
+	flags.StringVarP(&opts.configPath, "config", "c", "", "path to the ratify configuration file (default \"$HOME/.ratify/config.json\")")
+	flags.StringVarP(&opts.output, "output", "o", outputText, "output format, one of: text, json")
+	_ = cmd.MarkFlagRequired("subject")
+	return cmd
+}
+
+// runVerify executes the verification workflow for the `verify` command.
+func runVerify(cmd *cobra.Command, opts *verifyOptions) error {
+	if opts.output != outputText && opts.output != outputJSON {
+		return fmt.Errorf("invalid output format %q: must be one of %q or %q", opts.output, outputText, outputJSON)
+	}
+
+	scopedExecutor, err := loadExecutor(opts.configPath)
+	if err != nil {
+		return err
+	}
+
+	result, err := scopedExecutor.ValidateArtifact(cmd.Context(), opts.subject)
+	if err != nil {
+		return fmt.Errorf("failed to verify artifact %q: %w", opts.subject, err)
+	}
+
+	if err := printResult(cmd.OutOrStdout(), opts.subject, opts.output, result); err != nil {
+		return err
+	}
+
+	if !result.Succeeded {
+		return fmt.Errorf("artifact %q failed verification", opts.subject)
+	}
+	return nil
+}
+
+// loadExecutor reads the configuration file and builds a scoped executor.
+func loadExecutor(configPath string) (*executor.ScopedExecutor, error) {
+	path, err := resolveConfigPath(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read configuration file %q: %w", path, err)
+	}
+
+	var opts executor.Options
+	if err := json.Unmarshal(body, &opts); err != nil {
+		return nil, fmt.Errorf("failed to parse configuration file %q: %w", path, err)
+	}
+
+	scopedExecutor, err := executor.NewScopedExecutor(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize executor: %w", err)
+	}
+	return scopedExecutor, nil
+}
+
+// resolveConfigPath returns the configuration file path to use. It mirrors the
+// resolution order used by the Ratify Gatekeeper provider: an explicit path, the
+// RATIFY_CONFIG directory, or the default "$HOME/.ratify/config.json".
+func resolveConfigPath(configPath string) (string, error) {
+	if configPath != "" {
+		return configPath, nil
+	}
+	if dir := os.Getenv("RATIFY_CONFIG"); dir != "" {
+		return filepath.Join(dir, configFileName), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve home directory for default configuration path: %w", err)
+	}
+	return filepath.Join(home, configFileDir, configFileName), nil
+}

--- a/cmd/ratify/verify_extra_test.go
+++ b/cmd/ratify/verify_extra_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/notaryproject/ratify-go"
+	"github.com/notaryproject/ratify/v2/internal/store"
+	"github.com/notaryproject/ratify/v2/internal/verifier"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	testStoreType          = "cli-test-store"
+	testFailingStoreType   = "cli-test-failing-store"
+	testVerifierType       = "cli-test-verifier"
+	testSubjectRef         = "registry.example/repo:v1"
+	testSubjectDigest      = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	testSubjectMediaType   = "application/vnd.oci.image.manifest.v1+json"
+	testSubjectArtifactRef = "registry.example/repo@" + testSubjectDigest
+)
+
+// errStubStoreResolve is returned by the failing stub store to force
+// ValidateArtifact to fail during subject resolution.
+var errStubStoreResolve = errors.New("stub store: resolve failed")
+
+// stubStore is a minimal [ratify.Store] used to drive runVerify without a real
+// registry. When resolveErr is set, Resolve fails so ValidateArtifact errors.
+type stubStore struct {
+	resolveErr error
+}
+
+func (s *stubStore) Resolve(_ context.Context, _ string) (ocispec.Descriptor, error) {
+	if s.resolveErr != nil {
+		return ocispec.Descriptor{}, s.resolveErr
+	}
+	return ocispec.Descriptor{
+		MediaType: testSubjectMediaType,
+		Digest:    testSubjectDigest,
+		Size:      2,
+	}, nil
+}
+
+func (s *stubStore) ListReferrers(_ context.Context, _ string, _ []string, _ func(referrers []ocispec.Descriptor) error) error {
+	return nil
+}
+
+func (s *stubStore) FetchBlob(_ context.Context, _ string, _ ocispec.Descriptor) ([]byte, error) {
+	return nil, errors.New("stub store: blob not available")
+}
+
+func (s *stubStore) FetchManifest(_ context.Context, _ string, _ ocispec.Descriptor) ([]byte, error) {
+	return nil, errors.New("stub store: manifest not available")
+}
+
+func init() {
+	store.Register(testStoreType, func(store.NewOptions) (ratify.Store, error) {
+		return &stubStore{}, nil
+	})
+	store.Register(testFailingStoreType, func(store.NewOptions) (ratify.Store, error) {
+		return &stubStore{resolveErr: errStubStoreResolve}, nil
+	})
+	verifier.Register(testVerifierType, func(opts verifier.NewOptions, _ []string) (ratify.Verifier, error) {
+		return &stubVerifier{name: opts.Name}, nil
+	})
+}
+
+// writeExecutorConfig writes a valid executor configuration that references the
+// given store type and returns its path.
+func writeExecutorConfig(t *testing.T, storeType string) string {
+	t.Helper()
+	cfg := map[string]any{
+		"executors": []map[string]any{
+			{
+				"scopes":    []string{"registry.example"},
+				"verifiers": []map[string]any{{"name": "stub", "type": testVerifierType}},
+				"stores":    []map[string]any{{"type": storeType, "parameters": map[string]any{}}},
+			},
+		},
+	}
+	body, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	return path
+}
+
+func TestLoadExecutor_Valid(t *testing.T) {
+	path := writeExecutorConfig(t, testStoreType)
+	scoped, err := loadExecutor(path)
+	if err != nil {
+		t.Fatalf("unexpected error loading executor: %v", err)
+	}
+	if scoped == nil {
+		t.Fatal("expected a non-nil scoped executor")
+	}
+}
+
+func TestRunVerify_LoadExecutorError(t *testing.T) {
+	cmd := newVerifyCmd()
+	cmd.SetOut(new(bytesBuffer))
+	opts := &verifyOptions{
+		subject:    testSubjectRef,
+		output:     outputText,
+		configPath: filepath.Join(t.TempDir(), "missing.json"),
+	}
+	if err := runVerify(cmd, opts); err == nil {
+		t.Error("expected an error when the configuration file cannot be loaded")
+	}
+}
+
+func TestRunVerify_ValidateArtifactError(t *testing.T) {
+	cmd := newVerifyCmd()
+	cmd.SetOut(new(bytesBuffer))
+	cmd.SetContext(context.Background())
+	opts := &verifyOptions{
+		subject:    testSubjectArtifactRef,
+		output:     outputText,
+		configPath: writeExecutorConfig(t, testFailingStoreType),
+	}
+	err := runVerify(cmd, opts)
+	if err == nil {
+		t.Fatal("expected an error when artifact resolution fails")
+	}
+	if !strings.Contains(err.Error(), "failed to verify artifact") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunVerify_RendersResult(t *testing.T) {
+	cmd := newVerifyCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetContext(context.Background())
+	opts := &verifyOptions{
+		subject:    testSubjectArtifactRef,
+		output:     outputText,
+		configPath: writeExecutorConfig(t, testStoreType),
+	}
+	// The result may be a pass or a fail depending on ratify-go policy defaults;
+	// either way runVerify must render the report to the command's output.
+	_ = runVerify(cmd, opts)
+	if !strings.Contains(buf.String(), "Subject:") {
+		t.Errorf("expected rendered report output; got:\n%s", buf.String())
+	}
+}
+
+func TestNewRenderedReports_SkipsNilEntries(t *testing.T) {
+	reports := []*ratify.ValidationReport{
+		nil,
+		{
+			Subject:  testSubjectRef,
+			Artifact: ocispec.Descriptor{Digest: testSubjectDigest},
+			Results: []*ratify.VerificationResult{
+				nil,
+				{Verifier: &stubVerifier{name: "notation"}, Description: "ok"},
+			},
+		},
+	}
+	rendered := newRenderedReports(reports)
+	if len(rendered) != 1 {
+		t.Fatalf("expected nil report to be skipped, got %d reports", len(rendered))
+	}
+	if len(rendered[0].Results) != 1 {
+		t.Fatalf("expected nil result to be skipped, got %d results", len(rendered[0].Results))
+	}
+	if rendered[0].Results[0].Verifier != "notation" {
+		t.Errorf("unexpected verifier: %q", rendered[0].Results[0].Verifier)
+	}
+}
+
+func TestPrintResult_NestedReports(t *testing.T) {
+	result := &ratify.ValidationResult{
+		Succeeded: true,
+		ArtifactReports: []*ratify.ValidationReport{
+			{
+				Subject:  testSubjectRef,
+				Artifact: ocispec.Descriptor{Digest: testSubjectDigest},
+				Results: []*ratify.VerificationResult{
+					{Verifier: &stubVerifier{name: "notation"}, Description: "signature verified"},
+				},
+				ArtifactReports: []*ratify.ValidationReport{
+					{
+						Subject:  testSubjectRef,
+						Artifact: ocispec.Descriptor{Digest: "sha256:3333333333333333333333333333333333333333333333333333333333333333"},
+						Results: []*ratify.VerificationResult{
+							{Verifier: &stubVerifier{name: "cosign"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	var buf strings.Builder
+	if err := printResult(&buf, testSubjectRef, outputText, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"verifier=notation", "verifier=cosign", "sha256:3333"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("nested text output missing %q; got:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/ratify/verify_test.go
+++ b/cmd/ratify/verify_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveConfigPath(t *testing.T) {
+	t.Run("explicit path takes precedence", func(t *testing.T) {
+		t.Setenv("RATIFY_CONFIG", filepath.Join("some", "dir"))
+		got, err := resolveConfigPath("/custom/config.json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/custom/config.json" {
+			t.Errorf("got %q, want %q", got, "/custom/config.json")
+		}
+	})
+
+	t.Run("RATIFY_CONFIG directory is used", func(t *testing.T) {
+		dir := filepath.Join("ratify", "conf")
+		t.Setenv("RATIFY_CONFIG", dir)
+		got, err := resolveConfigPath("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join(dir, configFileName)
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("default home directory path", func(t *testing.T) {
+		t.Setenv("RATIFY_CONFIG", "")
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skipf("cannot determine home directory: %v", err)
+		}
+		got, err := resolveConfigPath("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join(home, configFileDir, configFileName)
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestLoadExecutor(t *testing.T) {
+	t.Run("missing file returns error", func(t *testing.T) {
+		_, err := loadExecutor(filepath.Join(t.TempDir(), "does-not-exist.json"))
+		if err == nil {
+			t.Fatal("expected an error for a missing configuration file")
+		}
+	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.json")
+		if err := os.WriteFile(path, []byte("{not-json"), 0o600); err != nil {
+			t.Fatalf("failed to write config: %v", err)
+		}
+		_, err := loadExecutor(path)
+		if err == nil {
+			t.Fatal("expected an error for invalid JSON")
+		}
+	})
+
+	t.Run("empty executors returns error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.json")
+		if err := os.WriteFile(path, []byte(`{"executors":[]}`), 0o600); err != nil {
+			t.Fatalf("failed to write config: %v", err)
+		}
+		_, err := loadExecutor(path)
+		if err == nil {
+			t.Fatal("expected an error when no executors are configured")
+		}
+	})
+}
+
+func TestRunVerify_InvalidOutputFormat(t *testing.T) {
+	cmd := newVerifyCmd()
+	opts := &verifyOptions{
+		subject: "registry.example/repo:v1",
+		output:  "yaml",
+	}
+	if err := runVerify(cmd, opts); err == nil {
+		t.Error("expected an error for an unsupported output format")
+	}
+}
+
+func TestVerifyCmd_RequiresSubject(t *testing.T) {
+	cmd := newVerifyCmd()
+	cmd.SetOut(new(bytesBuffer))
+	cmd.SetErr(new(bytesBuffer))
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected an error when --subject is not provided")
+	}
+}
+
+// bytesBuffer is a minimal io.Writer used to discard command output in tests.
+type bytesBuffer struct{}
+
+func (*bytesBuffer) Write(p []byte) (int, error) { return len(p), nil }

--- a/cmd/ratify/version.go
+++ b/cmd/ratify/version.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/notaryproject/ratify/v2/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// newVersionCmd creates the `ratify version` command.
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Show the ratify version information",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			w := cmd.OutOrStdout()
+			fmt.Fprintf(w, "Version:        %s\n", version.Version)
+			fmt.Fprintf(w, "Git Tag:        %s\n", version.GitTag)
+			fmt.Fprintf(w, "Git Commit:     %s\n", version.GitCommitHash)
+			fmt.Fprintf(w, "Git Tree State: %s\n", version.GitTreeState)
+			return nil
+		},
+	}
+}

--- a/cmd/ratify/version_test.go
+++ b/cmd/ratify/version_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/notaryproject/ratify/v2/internal/version"
+)
+
+func TestVersionCmd(t *testing.T) {
+	origVersion := version.Version
+	origTag := version.GitTag
+	origCommit := version.GitCommitHash
+	origTreeState := version.GitTreeState
+	t.Cleanup(func() {
+		version.Version = origVersion
+		version.GitTag = origTag
+		version.GitCommitHash = origCommit
+		version.GitTreeState = origTreeState
+	})
+
+	version.Version = "v2.0.0-test"
+	version.GitTag = "v2.0.0"
+	version.GitCommitHash = "abcdef123456"
+	version.GitTreeState = "clean"
+
+	cmd := newVersionCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("version command returned unexpected error: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{"v2.0.0-test", "v2.0.0", "abcdef123456", "clean"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("version output missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestVersionCmd_RejectsArgs(t *testing.T) {
+	cmd := newVersionCmd()
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"unexpected"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected an error when passing arguments to the version command")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/sigstore/sigstore-go v1.2.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spdx/tools-golang v0.5.5
+	github.com/spf13/cobra v1.10.2
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
@@ -105,6 +106,7 @@ require (
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/in-toto/attestation v1.2.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/miekg/dns v1.1.61 // indirect
 	github.com/notaryproject/notation-plugin-framework-go v1.0.0 // indirect
 	github.com/notaryproject/tspclient-go v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,7 @@ github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUo
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/coreos/go-oidc/v3 v3.20.0 h1:EtE0WIBHk03N+DqGkY4+UONzzZHk7amKt6IyNd7OsZE=
 github.com/coreos/go-oidc/v3 v3.20.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
@@ -515,6 +516,7 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sassoftware/relic v7.2.1+incompatible h1:Pwyh1F3I0r4clFJXkSI8bOyJINGqpgjJU3DYAZeI05A=
@@ -558,6 +560,7 @@ github.com/spdx/tools-golang v0.5.5 h1:61c0KLfAcNqAjlg6UNMdkwpMernhw3zVRwDZ2x9XO
 github.com/spdx/tools-golang v0.5.5/go.mod h1:MVIsXx8ZZzaRWNQpUDhC4Dud34edUYJYecciXgrw5vE=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/httpserver/handlers_test.go
+++ b/internal/httpserver/handlers_test.go
@@ -448,8 +448,7 @@ func TestVerifyHandler_LogsFailure(t *testing.T) {
 	entry := findEntry(hook, logrus.ErrorLevel, "failed to handle the verification request")
 	if entry == nil {
 		t.Fatal("expected the verify handler to log the error it previously discarded")
-	}
-	if entry.Data["trace-id"] == nil {
+	} else if entry.Data["trace-id"] == nil {
 		t.Error("expected the logged entry to carry a trace ID")
 	}
 }
@@ -478,8 +477,7 @@ func TestMutateHandler_LogsFailure(t *testing.T) {
 	entry := findEntry(hook, logrus.ErrorLevel, "failed to handle the mutation request")
 	if entry == nil {
 		t.Fatal("expected the mutate handler to log the error it previously discarded")
-	}
-	if entry.Data["trace-id"] == nil {
+	} else if entry.Data["trace-id"] == nil {
 		t.Error("expected the logged entry to carry a trace ID")
 	}
 }
@@ -576,8 +574,7 @@ func TestVerify_LogsOutcomeOnCacheHit(t *testing.T) {
 	entry := findEntry(hook, logrus.InfoLevel, artifact)
 	if entry == nil {
 		t.Fatal("expected a cached verification result to still be logged at info level")
-	}
-	if !strings.Contains(entry.Message, "succeeded=false") {
+	} else if !strings.Contains(entry.Message, "succeeded=false") {
 		t.Errorf("expected the violation to be greppable, got: %s", entry.Message)
 	}
 }

--- a/internal/httpserver/handlers_test.go
+++ b/internal/httpserver/handlers_test.go
@@ -543,10 +543,11 @@ func TestLogVerificationResult(t *testing.T) {
 	entry := findEntry(hook, logrus.InfoLevel, "registry.example/app:v1")
 	if entry == nil {
 		t.Fatal("expected the verification result to be logged at info level")
-	}
-	for _, want := range []string{"notation-1", "signature is not produced by a trusted signer", `"succeeded":false`} {
-		if !strings.Contains(entry.Message, want) {
-			t.Errorf("expected the logged result to contain %q, got: %s", want, entry.Message)
+	} else {
+		for _, want := range []string{"notation-1", "signature is not produced by a trusted signer", `"succeeded":false`} {
+			if !strings.Contains(entry.Message, want) {
+				t.Errorf("expected the logged result to contain %q, got: %s", want, entry.Message)
+			}
 		}
 	}
 }
@@ -588,8 +589,7 @@ func TestLogVerificationResult_Violation(t *testing.T) {
 	entry := findEntry(hook, logrus.InfoLevel, "registry.example/app:v1")
 	if entry == nil {
 		t.Fatal("expected a violation to be logged at info level")
-	}
-	if !strings.Contains(entry.Message, "succeeded=false") {
+	} else if !strings.Contains(entry.Message, "succeeded=false") {
 		t.Errorf("expected succeeded=false in the message, got: %s", entry.Message)
 	}
 }
@@ -609,8 +609,7 @@ func TestLogVerificationResult_UnmarshalableReport(t *testing.T) {
 	entry := findEntry(hook, logrus.InfoLevel, "registry.example/app:v1")
 	if entry == nil {
 		t.Fatal("expected the outcome to be logged even when the report cannot be marshalled")
-	}
-	if strings.Contains(entry.Message, "report=") {
+	} else if strings.Contains(entry.Message, "report=") {
 		t.Errorf("expected the fallback message without a report, got: %s", entry.Message)
 	}
 }

--- a/internal/store/credentialprovider/azure/register_test.go
+++ b/internal/store/credentialprovider/azure/register_test.go
@@ -1016,8 +1016,7 @@ func TestResolveTokenTTL(t *testing.T) {
 			entry := hook.LastEntry()
 			if entry == nil {
 				t.Fatalf("resolveTokenTTL() logged nothing, want a message containing %q", tt.wantLog)
-			}
-			if !contains(entry.Message, tt.wantLog) {
+			} else if !contains(entry.Message, tt.wantLog) {
 				t.Errorf("resolveTokenTTL() logged %q, want it to contain %q", entry.Message, tt.wantLog)
 			}
 		})

--- a/internal/store/credentialprovider/cachedprovider_test.go
+++ b/internal/store/credentialprovider/cachedprovider_test.go
@@ -85,14 +85,14 @@ func TestNewCachedProvider(t *testing.T) {
 
 	if provider == nil {
 		t.Fatal("Expected non-nil provider")
-	}
+	} else {
+		if provider.source != mockSource {
+			t.Error("Expected source to be set correctly")
+		}
 
-	if provider.source != mockSource {
-		t.Error("Expected source to be set correctly")
-	}
-
-	if provider.cache == nil {
-		t.Error("Expected cache to be initialized")
+		if provider.cache == nil {
+			t.Error("Expected cache to be initialized")
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Ratify v2 currently only ships the `ratify-gatekeeper-provider` binary; the
roadmap ([#2362](https://github.com/notaryproject/ratify/issues/2362)) calls for
a standalone CLI built on `ratify-go` to be merged into this repo. This PR adds
that CLI entrypoint under `cmd/ratify`.

The CLI reuses the existing `internal/executor` (which is backed by
`ratify-go`) and shares the exact same configuration format as the Gatekeeper
provider, so there is a single source of truth for verifier/store/policy setup.

**Commands**

- `ratify verify --subject <ref> [--config <path>] [--output text|json]`
  loads the executor configuration, validates the subject artifact, prints a
  text or JSON report, and exits non-zero when the artifact fails the policy or
  an error occurs. Config resolution mirrors the provider: explicit `--config`,
  then `RATIFY_CONFIG`, then `$HOME/.ratify/config.json`.
- `ratify version` prints the embedded version information.

The CLI registers the same verifiers, stores, credential providers, and key
providers as the Gatekeeper provider (`register.go`) for feature parity, and the
new binary is published via goreleaser (with version `ldflags`).

### Which issue(s) does this PR resolve?

Part of #2362 (Ratify v2 CLI sub-project).

### Type of change

- New feature (non-breaking change which adds functionality)

## Testing and verification

- `go build ./...` — whole module builds.
- `go test ./cmd/ratify/...` — new unit tests cover config-path resolution,
  executor loading (missing file / invalid JSON / empty executors), output
  format validation, required-flag handling, result rendering (text + JSON),
  and the `version` command.
- `go vet ./cmd/ratify/...` and `golangci-lint run ./cmd/ratify/...` — no
  issues.
- Manual smoke test: `ratify --help`, `ratify version`, and
  `ratify verify --subject <ref>` against a local config.

## Checklist

- [x] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [x] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x] Do all new files have appropriate license header?

## Post merge requirements

- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
